### PR TITLE
Rename macro to account for repo rename

### DIFF
--- a/ci/jjb/jobs/macros.yaml
+++ b/ci/jjb/jobs/macros.yaml
@@ -182,7 +182,7 @@
             } catch(NullPointerException ex) {}
 
 - scm:
-    name: pulp-packaging-github
+    name: pulp-ci-github
     scm:
         - git:
             url: https://github.com/pulp/pulp-ci.git

--- a/ci/jjb/jobs/pulp-backup.yaml
+++ b/ci/jjb/jobs/pulp-backup.yaml
@@ -11,7 +11,7 @@
             artifact-days-to-keep: 7
             artifact-num-to-keep: 3
     scm:
-        - pulp-packaging-github
+        - pulp-ci-github
     wrappers:
         - config-file-provider:
             files:

--- a/ci/jjb/jobs/pulp-dev.yaml
+++ b/ci/jjb/jobs/pulp-dev.yaml
@@ -4,7 +4,7 @@
     properties:
         - qe-ownership
     scm:
-        - pulp-packaging-github
+        - pulp-ci-github
     wrappers:
         - config-file-provider:
             files:

--- a/ci/jjb/jobs/pulp-installer.yaml
+++ b/ci/jjb/jobs/pulp-installer.yaml
@@ -57,7 +57,7 @@
     properties:
       - qe-ownership
     scm:
-        - pulp-packaging-github
+        - pulp-ci-github
     wrappers:
         - config-file-provider:
             files:

--- a/ci/jjb/jobs/pulp-packaging-build.yaml
+++ b/ci/jjb/jobs/pulp-packaging-build.yaml
@@ -4,7 +4,7 @@
     properties:
         - build-ownership
     scm:
-        - pulp-packaging-github
+        - pulp-ci-github
     wrappers:
         - config-file-provider:
             files:

--- a/ci/jjb/jobs/pulp-restore.yaml
+++ b/ci/jjb/jobs/pulp-restore.yaml
@@ -4,7 +4,7 @@
     properties:
         - qe-ownership
     scm:
-        - pulp-packaging-github
+        - pulp-ci-github
     wrappers:
         - config-file-provider:
             files:

--- a/ci/jjb/jobs/pulp-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp-smash-runner.yaml
@@ -57,7 +57,7 @@
     properties:
         - qe-ownership
     scm:
-        - pulp-packaging-github
+        - pulp-ci-github
     wrappers:
         - ansicolor
         - timeout:

--- a/ci/jjb/jobs/pulp-upgrade.yaml
+++ b/ci/jjb/jobs/pulp-upgrade.yaml
@@ -7,7 +7,7 @@
     properties:
         - qe-ownership
     scm:
-        - pulp-packaging-github
+        - pulp-ci-github
     triggers:
         - timed: 'H H * * 1,4'
     wrappers:


### PR DESCRIPTION
Rename macro `pulp-packaging-github` to `pulp-ci-github`. Do this
because the macro has been changed. It used to clone no
`pulp/pulp_packaging`, but now clones `pulp/pulp-ci`.