### PR TITLE
Clean up old jjb builds

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -4,10 +4,6 @@
      - 'build-automation-repo-{release_config}'
      - 'build-automation-promote-{release_config}'
     release_config:
-      - 2.12-dev:
-         version: '2.12'
-      - 2.13-dev:
-         version: '2.13'
       - 2.14-dev:
          version: '2.14'
       - master:
@@ -29,17 +25,11 @@
     pulp_version:
         - '2.15':
             reverse_trigger: 'master'
-    exclude:
-        - pulp_version: '2.12'
-          os: 'f26'
-        - pulp_version: '2.13'
-          os: 'f26'
     reverse_trigger: '{pulp_version}-dev'
     jobs:
         - pulp-packaging-{pulp_version}-dev-{os}
     release_config:
       - master
-
 
 - project:
     name: ci-update-jobs
@@ -51,7 +41,6 @@
     jobs:
      - 'docs-builder-{release_config}'
     release_config:
-     - 2.13-dev
      - 2.14-dev
      - master
      - 3.0-dev
@@ -62,8 +51,6 @@
     jobs:
      - 'docs-builder-{release_config}'
     release_config:
-     - 2.13-build
-     - 2.13-release
      - 2.14-build
      - 2.14-release
     trigger_times: ''
@@ -76,16 +63,9 @@
         - 'f26'
         - 'rhel7'
     pulp_version:
-        - '2.12'
-        - '2.13'
         - '2.14'
         - '2.15':
             reverse_trigger: 'master'
-    exclude:
-        - pulp_version: '2.12'
-          os: 'f26'
-        - pulp_version: '2.13'
-          os: 'f26'
     reverse_trigger: '{pulp_version}-dev'
     jobs:
         - pulp-{pulp_version}-dev-{os}
@@ -154,43 +134,8 @@
         - 2.13-stable
         - 2.14-stable
     upgrade_pulp_version:
-        - 2.11-beta
-        - 2.12-beta
-        - 2.13-beta
         - 2.14-beta
     exclude:
-        - pulp_version: 2.8-stable
-          upgrade_pulp_version: 2.13-beta
-        - pulp_version: 2.9-stable
-          upgrade_pulp_version: 2.13-beta
-        - pulp_version: 2.10-stable
-          upgrade_pulp_version: 2.13-beta
-        - pulp_version: 2.11-stable
-          upgrade_pulp_version: 2.10-beta
-        - pulp_version: 2.12-stable
-          upgrade_pulp_version: 2.10-beta
-        - pulp_version: 2.12-stable
-          upgrade_pulp_version: 2.11-beta
-        - pulp_version: 2.13-stable
-          upgrade_pulp_version: 2.10-beta
-        - pulp_version: 2.13-stable
-          upgrade_pulp_version: 2.11-beta
-        - pulp_version: 2.13-stable
-          upgrade_pulp_version: 2.12-beta
-        - pulp_version: 2.8-stable
-          upgrade_pulp_version: 2.14-beta
-        - pulp_version: 2.9-stable
-          upgrade_pulp_version: 2.14-beta
-        - pulp_version: 2.10-stable
-          upgrade_pulp_version: 2.14-beta
-        - pulp_version: 2.14-stable
-          upgrade_pulp_version: 2.10-beta
-        - pulp_version: 2.14-stable
-          upgrade_pulp_version: 2.11-beta
-        - pulp_version: 2.14-stable
-          upgrade_pulp_version: 2.12-beta
-        - pulp_version: 2.14-stable
-          upgrade_pulp_version: 2.13-beta
         - os: f24
           pulp_version: 2.8-stable
         - os: f24
@@ -201,10 +146,6 @@
           pulp_version: 2.9-stable
         - os: f25
           pulp_version: 2.10-stable
-        - os: rhel6
-          upgrade_pulp_version: 2.12-beta
-        - os: rhel6
-          upgrade_pulp_version: 2.13-beta
         - os: rhel6
           upgrade_pulp_version: 2.14-beta
     jobs:
@@ -226,11 +167,6 @@
         - downstream:
             satellite_distribution: 'INTERNAL'
             satellite_version: '6.3'
-
-- project:
-    name: sync
-    jobs:
-     - sync-triage-logs
 
 - project:
     name: unittests
@@ -255,11 +191,6 @@
           min_coverage: 100
           unittest_branches:
             - master
-            - 2.0-dev
-            - 2.0-release
-            - 2.1-dev
-            - 2.2-dev
-            - 2.4-dev
             - 2.5-dev
           unittest_platforms:
             - f24-np
@@ -272,9 +203,6 @@
           min_coverage: 100
           unittest_branches:
             - master
-            - 1.1-dev
-            - 1.1-release
-            - 1.2-dev
             - 1.3-dev
           unittest_platforms:
             - f24-np
@@ -286,12 +214,6 @@
       - pulp_puppet:
           min_coverage: 95
           unittest_branches:
-            - 2.8-dev
-            - 2.9-dev
-            - 2.10-dev
-            - 2.11-dev
-            - 2.12-dev
-            - 2.13-dev
             - 2.14-dev
             - master
           unittest_platforms:
@@ -304,8 +226,6 @@
       - pulp_python:
           min_coverage: 100
           unittest_branches:
-            - 1.1-dev
-            - 1.1-release
             - 2.0-dev
             - master
           unittest_platforms:
@@ -318,12 +238,6 @@
       - pulp_rpm:
           min_coverage: 87
           unittest_branches:
-            - 2.8-dev
-            - 2.9-dev
-            - 2.10-dev
-            - 2.11-dev
-            - 2.12-dev
-            - 2.13-dev
             - 2.14-dev
             - master
           unittest_platforms:
@@ -363,7 +277,6 @@
       - pulp_docker:
           docs_branches:
             - master
-            - 2.4-dev
             - 2.5-dev
           docs_platforms:
             - f25-np
@@ -373,7 +286,6 @@
       - pulp_ostree:
           docs_branches:
             - master
-            - 1.2-dev
             - 1.3-dev
           docs_platforms:
             - f25-np
@@ -383,7 +295,6 @@
       - pulp_puppet:
           docs_branches:
             - 2.14-dev
-            - 2.13-dev
             - master
           docs_platforms:
             - f25-np
@@ -393,7 +304,6 @@
       - pulp_rpm:
           docs_branches:
             - 2.14-dev
-            - 2.13-dev
             - master
           docs_platforms:
             - f25-np

--- a/ci/jjb/jobs/unittests.yaml
+++ b/ci/jjb/jobs/unittests.yaml
@@ -46,18 +46,6 @@
           allow-whitelist-orgs-as-admins: true
           # only-trigger-phrase: true
           white-list-target-branches:
-            - 2.8-dev
-            - 2.8-release
-            - 2.9-dev
-            - 2.9-release
-            - 2.10-dev
-            - 2.10-release
-            - 2.11-dev
-            - 2.11-release
-            - 2.12-dev
-            - 2.12-release
-            - 2.13-dev
-            - 2.13-release
             - 2.14-dev
             - 2.14-release
             - master


### PR DESCRIPTION
build-automation, docs-build-nightly, docs-build-manually, pulp-dev
has the 2.12-dev and 2.13-dev pulp versions removed, since no changes
are being made to those releases.

pulp-packaging-build has unnecessary excludes removed

pulp-upgrade matrix has been updated to only try to upgrade to the
latest pulp.

sync has been removed. This job was used to sync triage logs. The
new triage logs are syncing with a cronjob.

unittest jobs has old versions removed, since no PRs should be landing
against the current dev-branch.