### PR TITLE
Run the Pulp 3 functional tests every day

### DIFF
--- a/ci/jjb/jobs/pulp-3-dev.yaml
+++ b/ci/jjb/jobs/pulp-3-dev.yaml
@@ -19,6 +19,8 @@
           branches:
             - '3.0-dev'
           skip-tag: true
+    triggers:
+        - timed: "H 2 * * *"
     builders:
       # Install and start Pulp 3.
       - shell: |


### PR DESCRIPTION
Currently, the functional tests for Pulp 3 only run when manually
triggered. This isn't good. Make Jenkins automatically run them on a
daily basis.

Run these jobs at some time between 02:00 and 02:59 each day. This time
is chosen because it is earlier than the build-automation and
pulp-packaging jobs, which run between 04:00 and 05:59 each day. Running
these jobs at a different time should help to prevent deadlocks. (The
`pulp-dev*` jobs trigger pulp-smash-runner jobs. If all available VMs
have been used up, then no pulp-smash-runner jobs can execute, and a
deadlock occurs.)