### PR TITLE
Restart qpidd after pulp server is installed.

### DIFF
--- a/ci/ansible/roles/pulp/handlers/main.yaml
+++ b/ci/ansible/roles/pulp/handlers/main.yaml
@@ -27,3 +27,8 @@
 
 - name: Save IPv4 iptables configuration
   shell: 'iptables-save > /etc/sysconfig/iptables'
+
+- name: Restart qpidd service
+  service:
+    name: qpidd
+    state: restarted

--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -138,6 +138,7 @@
   - name: Install Pulp Server
     action: "{{ ansible_pkg_mgr }} name=@pulp-server-qpid"
     notify:
+      - Restart qpidd service
       - Restart Apache service
       - Restart Pulp workers service
       - Restart Pulp celerybeat service


### PR DESCRIPTION
In f27 there is a exisiting issue with qpid's selinux policies,
this is currently patched in pulp's selinux policies, so qpidd needs to be 
restarted after pulp is installed to be able to run.