### PR TITLE
Add job to build Vagrant boxes for Pulp 3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ This is an alphabetical (by last name) list of the authors of the Pulp project.
 If you submit a pull request to Pulp and your name is not on this list, please
 add yourself.
 
+Muhammad Ammar Ansari (mansari@redhat.com)
 Jeremy Cline (jcline@redhat.com)
 Filip Dobrovolny (fdobrovo@redhat.com)
 Justin Garrison (justinleegarrison@gmail.com)

--- a/ci/ansible/pulp_build_box.yml
+++ b/ci/ansible/pulp_build_box.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - role: pulp-build

--- a/ci/ansible/pulp_build_environment.yml
+++ b/ci/ansible/pulp_build_environment.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  roles:
+    - role: pulp-packer
+    - role: pulp-virtualbox
+    - role: pulp-libvirtd
+    - role: pulp-galaxy-ansible

--- a/ci/ansible/roles/pulp-build/tasks/main.yml
+++ b/ci/ansible/roles/pulp-build/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Update box version
+  lineinfile:
+    path: pulpcore.json
+    regexp: 'version'
+    line: "\"version\": \"{{ '%Y%m%d' | strftime }}\""
+
+- name: Reboot Server
+  command: /sbin/shutdown -r
+  async: 0
+  poll: 0
+
+- name: Wait for remote host to reboot
+  wait_for_connection:
+    delay: 60
+
+- name: Build image
+  command: packer build -var 'vagrant_cloud_token'={{ vagrant_cloud_token }} -force -parallel=false {{ ansible_user_dir }}/pulpcore.json
+  async: 0
+  poll: 0

--- a/ci/ansible/roles/pulp-galaxy-ansible/defaults/main.yml
+++ b/ci/ansible/roles/pulp-galaxy-ansible/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+box_name: pulp/pulpcore

--- a/ci/ansible/roles/pulp-galaxy-ansible/files/motd
+++ b/ci/ansible/roles/pulp-galaxy-ansible/files/motd
@@ -1,0 +1,8 @@
+
+Welcome to the Pulp 3 dev environment!
+
+To get you started, we have built a nice plugin writer's guide for
+you - https://docs.pulpproject.org/en/3.0/nightly/plugins/plugin-writer/ and you can
+also ask questions in #pulp on Freenode IRC.
+
+Happy hacking, and thanks for your contribution!

--- a/ci/ansible/roles/pulp-galaxy-ansible/tasks/main.yml
+++ b/ci/ansible/roles/pulp-galaxy-ansible/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Download installation playbook
+  get_url:
+    url: https://raw.githubusercontent.com/pulp/devel/3.0-dev/ansible/deploy-pulp3.yml
+    dest: "{{ ansible_user_dir }}"
+
+- name: Download requirements.yml
+  get_url:
+    url: https://raw.githubusercontent.com/pulp/devel/3.0-dev/ansible/requirements.yml
+    dest: "{{ ansible_user_dir }}"
+
+- name: Install ansible
+  package:
+    name: ansible
+    state: installed
+
+- name: Install ansible galaxy roles
+  command: ansible-galaxy install -r requirements.yml
+
+- name: Export motd
+  copy:
+    src: motd
+    dest: "{{ ansible_user_dir }}/motd"
+
+- name: Export packer template
+  template:
+    src: pulpcore.json.jj2
+    dest: "{{ ansible_user_dir }}/pulpcore.json"

--- a/ci/ansible/roles/pulp-galaxy-ansible/templates/pulpcore.json.jj2
+++ b/ci/ansible/roles/pulp-galaxy-ansible/templates/pulpcore.json.jj2
@@ -1,0 +1,100 @@
+{
+  "variables": {
+    "vagrant_cloud_token": ""
+  },
+  "builders":
+  [
+    {
+      "type": "virtualbox-ovf",
+      "source_path": "{{ ovf_path }}",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "60s" ,
+      "headless": true,
+      "boot_wait": "10s",
+      {% raw %}
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--memory", "4096"],
+        ["modifyvm", "{{.Name}}", "--natdnshostresolver1", "on"]
+      ],
+      {% endraw %}
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now"
+    },
+    {
+      "type": "qemu",
+      "accelerator": "kvm",
+      "iso_url": "{{ img_path }}",
+      "iso_checksum_type": "none",
+      "qemu_binary": "qemu-kvm",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "60s",
+      "headless": true,
+      "boot_wait": "10s",
+      "disk_image": true,
+      "disk_size": 40960,
+      "qemuargs": [
+        [ "-m", "4096M" ]
+      ],
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now"
+    }
+  ],
+  "provisioners":
+  [
+    {
+      "type": "file",
+      "source": "motd",
+      "destination": "/tmp/motd"
+    },
+    {
+      "type":"shell",
+      "only": ["virtualbox-ovf"],
+      "inline": [
+        "sudo mkdir -p /tmp/vboxguest",
+        "sudo mount -t iso9660 -o loop /home/vagrant/VBoxGuestAdditions.iso /tmp/vboxguest",
+        "cd /tmp/vboxguest",
+        "sudo dnf -y install dkms kernel-devel-$(uname -r) gcc",
+        "sudo ./VBoxLinuxAdditions.run",
+        "cd /tmp",
+        "sudo umount /tmp/vboxguest",
+        "sudo rmdir /tmp/vboxguest",
+        "rm /home/vagrant/VBoxGuestAdditions.iso"
+      ]
+    },
+    {
+      "type":"ansible",
+      "playbook_file": "deploy-pulp3.yml",
+      "user": "vagrant"
+    },
+    {
+      "type":"shell",
+      "inline": [
+        "sudo mv /tmp/motd /etc/motd",
+        "sudo rm /etc/yum.repos.d/epel.repo",
+        "sudo dnf -y install git httpie",
+        "echo 'machine localhost' >> /home/vagrant/.netrc",
+        "echo 'login admin' >> /home/vagrant/.netrc",
+        "echo 'password admin' >> /home/vagrant/.netrc",
+        "sudo sed -i 's/enforcing/permissive/' /etc/selinux/config"
+      ]
+    }
+  ],
+  "post-processors": 
+  [
+    [
+      {
+        "type": "vagrant"
+      },
+      {
+        "type": "vagrant-cloud",
+        {% raw %}
+        "access_token": "{{user `vagrant_cloud_token`}}",
+        {% endraw %}
+        "box_tag": "{{ box_name }}",
+        "version": "{{ '%Y%m%d' | strftime }}"
+      }
+    ]
+  ]
+}

--- a/ci/ansible/roles/pulp-libvirtd/files/custom.sh
+++ b/ci/ansible/roles/pulp-libvirtd/files/custom.sh
@@ -1,0 +1,1 @@
+PATH=$PATH:/usr/libexec

--- a/ci/ansible/roles/pulp-libvirtd/tasks/main.yml
+++ b/ci/ansible/roles/pulp-libvirtd/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+- name: Install KVM and its dependencies
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - qemu-kvm
+    - qemu-img
+    - virt-manager
+    - libvirt
+    - libvirt-python
+    - libvirt-client
+    - virt-install
+    - virt-viewer
+    - bridge-utils
+
+- name: Ensure /etc/profile.d/custom.sh exists
+  file:
+    path: /etc/profile.d/custom.sh
+    state: touch
+
+- name: Add /usr/libexec to $PATH
+  copy:
+    dest: /etc/profile.d/custom.sh
+    content: 'PATH=$PATH:/usr/libexec'
+
+- name: Add /usr/libexec to $PATH
+  copy:
+    dest: /etc/profile.d/
+    src: custom.sh
+  
+- name: Start and enable libvirtd service
+  systemd:
+    name: libvirtd
+    state: started
+    enabled: yes
+
+- name: Get KVM status
+  systemd:
+    name: libvirtd
+  register: libvirt
+
+- name: Check if kernel modules are loaded and active
+  fail:
+    msg: "The Kernel Modules are inactive or not loaded"
+  when: (libvirt.status.ActiveState != 'active') or
+        (libvirt.status.LoadState != 'loaded')
+
+- name: Add F26 libvirt box
+  command: vagrant box add fedora/26-cloud-base --provider libvirt --force
+  register: check_if_added
+  until: not check_if_added | failed
+
+- name: Find img file for Fedora box
+  find:
+    paths: ~/.vagrant.d/boxes/fedora-VAGRANTSLASH-26-cloud-base
+    recurse: yes
+    patterns: 'box.img'
+  register: results
+
+- assert:
+    that: results['matched'] == 1
+    msg: "More than one .img files were found for Fedora box"
+
+- name: Set img file path
+  set_fact:
+    img_path: "{{ results['files'][0]['path'] }}"

--- a/ci/ansible/roles/pulp-packer/defaults/main.yml
+++ b/ci/ansible/roles/pulp-packer/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+packer_install_directory: "/usr/local/bin"
+packer_version: 1.1.3

--- a/ci/ansible/roles/pulp-packer/tasks/main.yml
+++ b/ci/ansible/roles/pulp-packer/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Check if packer is already installed
+  stat:
+    path: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer"
+  register: check_existing_packer
+
+- block:
+    - name: Create packer version directory
+      file:
+        name: "{{ packer_install_directory }}/packer_{{ packer_version }}"
+        state: directory
+
+    - name: Download packer archive
+      get_url:
+        url: "https://releases.hashicorp.com/packer/{{ packer_version }}/packer_{{ packer_version }}_linux_{{ ansible_architecture|regex_replace('x86_64','amd64') }}.zip"
+        dest: "{{ packer_install_directory }}/packer_{{ packer_version }}/"
+        timeout: 1000
+      register: download_packer_archive
+
+    - name: Install unzip
+      package:
+        name: unzip
+      when: download_packer_archive.changed
+
+    - name: Unarchive packer
+      unarchive:
+        src: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer_{{ packer_version }}_linux_{{ ansible_architecture|regex_replace('x86_64','amd64') }}.zip"
+        dest: "{{ packer_install_directory }}/packer_{{ packer_version }}/"
+        remote_src: yes
+      when: download_packer_archive.changed
+
+    - name: Remove packer archive
+      file:
+        path: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer_{{ packer_version }}_linux_{{ ansible_architecture|regex_replace('x86_64','amd64') }}.zip"
+        state: absent
+
+  when: not check_existing_packer.stat.exists
+
+- name: Symlink packer to correct version
+  file:
+    path: "{{ packer_install_directory }}/packer"
+    src: "{{ packer_install_directory }}/packer_{{ packer_version }}/packer"
+    state: link
+    force: yes
+    mode: 0777

--- a/ci/ansible/roles/pulp-virtualbox/defaults/main.yml
+++ b/ci/ansible/roles/pulp-virtualbox/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+virtualbox_repo: http://download.virtualbox.org/virtualbox/rpm/rhel/virtualbox.repo
+virtualbox_key: https://www.virtualbox.org/download/oracle_vbox.asc
+vagrant_url: https://releases.hashicorp.com/vagrant/2.0.1/vagrant_2.0.1_x86_64.rpm

--- a/ci/ansible/roles/pulp-virtualbox/tasks/main.yml
+++ b/ci/ansible/roles/pulp-virtualbox/tasks/main.yml
@@ -1,0 +1,88 @@
+---
+- name: Update
+  yum:
+    name: "*"
+    state: latest
+  register: updated
+
+- name: Reboot Server
+  command: /sbin/shutdown -r
+  poll: 0
+  when: updated | changed
+
+- name: Wait for remote host to reboot
+  wait_for_connection:
+    delay: 60
+  when: updated | changed
+
+- name: Get VirtualBox repo file
+  get_url:
+    url: "{{ virtualbox_repo }}"
+    dest: /etc/yum.repos.d/virtualbox.repo
+
+- name: Get VirtualBox GPG key
+  rpm_key:
+    key: "{{ virtualbox_key }}"
+    state: present
+
+- name: Add repository
+  yum:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+    state: present
+
+- name: Add EPEL GPG key
+  rpm_key:
+    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}
+    state: present
+
+- name: Install VirtualBox and its dependencies
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - kernel-devel
+    - dkms
+    - gcc
+    - make
+    - VirtualBox-5.1
+
+- name: Compile Kernel modules
+  command: /sbin/vboxconfig
+
+- name: Get Virtual Box status
+  systemd:
+    name: vboxdrv
+  register: vbox
+
+- name: Check if kernel modules are loaded and active
+  fail:
+    msg: "The Kernel Modules are inactive or not loaded"
+  when: (vbox.status.ActiveState != 'active') or
+        (vbox.status.LoadState != 'loaded')
+
+- name: Install vagrant
+  package:
+    name: "{{ vagrant_url }}"
+    state: present
+  register: check_if_installed
+  until: not check_if_installed | failed
+
+- name: Add F26 virtualbox
+  command: vagrant box add fedora/26-cloud-base --provider virtualbox --force
+  register: check_if_added
+  until: not check_if_added | failed
+
+- name: Find ovf file for Fedora box
+  find:
+    paths: ~/.vagrant.d/boxes/fedora-VAGRANTSLASH-26-cloud-base
+    recurse: yes
+    patterns: 'box.ovf'
+  register: results
+
+- assert:
+    that: results['matched'] == 1
+    msg: "More than one .ovf files were found for Fedora box"
+
+- name: Set ovf file path
+  set_fact:
+    ovf_path: "{{ results['files'][0]['path'] }}"

--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -109,6 +109,16 @@
       - pulp-3-installer
 
 - project:
+    name: pulp-3-build-box
+    jobs:
+      - pulp-3-build-box
+
+- project:
+    name: pulp-3-build-environment
+    jobs:
+      - pulp-3-build-environment
+      
+- project:
     name: pulp-upgrade
     os:
         - f24

--- a/ci/jjb/jobs/pulp-3-build-box.yml
+++ b/ci/jjb/jobs/pulp-3-build-box.yml
@@ -1,0 +1,59 @@
+- job:
+    name: pulp-3-build-box
+    concurrent: true
+    node: 'fedora-np'
+    description: |
+      <p>
+        Build Vagrant box pre-installed with Pulp 3 on the host identified by the job parameter
+        <code>HOSTNAME</code>.
+      </p>
+      <p>
+        This job requires two hosts: one for use as an Ansible control host, and
+        one on which to build the Vagrant box. Jenkins is responsible for providing the
+        control host, and you are responsible for providing the build environment.
+        When this job is executed, Jenkins will configure the control host, by
+        doing things like installing Ansible and configuring SSH keys. Then, the
+        control host will reach out and build a Vagrant box onto the host identified
+        by <code>HOSTNAME</code>.
+      </p>
+      <p>
+        Ensure the following is in <code>~/.ssh/authorized_keys</code> on the
+        Pulp 3 host:
+      </p>
+      <pre>
+        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6DJ8fmd61DWPCMiOEuy96ajI7rL3rWu7C9NQhE9a4SfyaiBcghREHJNCz9LGJ57jtOmNV0+UEDhyvTckZI2YQeDqGCP/xO9B+5gQNlyGZ9gSmFz+68NhYQ0vRekikpb9jNdy6ZZbfZDLp1w7dxqDIKfoyu7QO3Qr3E/9CpiucQif2p+oQOVOCdKEjvGYNkYQks0jVTYNRscgmcezpfLKhqWzAre5+JaMB0kRD5Nqadm2uXKZ4cNYStrpZ4xUrnMvAqjormxW2VJNx+0716Wc2Byhg8Nva+bsOkxp/GewBWHfNPtzQGMsL7oYZPtOd/LrmyYeu/M5Uz7/6QCv4N90P pulp
+      </pre>
+      <p>
+        In addition, ensure the build environment satisfies the <a
+        href="http://docs.ansible.com/ansible/latest/intro_installation.html#managed-node-requirements">managed
+        node requirements</a>.
+      </p>
+    parameters:
+      - string:
+          name: HOSTNAME
+          default: 10.13.129.54
+      - string:
+          name: USER
+          default: root 
+    properties:
+        - dev-ownership
+    scm:
+      - git:
+          url: https://github.com/pulp/pulp-ci.git
+    triggers:
+        - timed: "H 2 * * *"
+    wrappers:
+      - jenkins-ssh-credentials
+      - credentials-binding:
+            - text:
+                credential-id: 3fd73f04-16df-42dc-bbcf-2911d7406f62
+                variable: VAGRANT_CLOUD_TOKEN
+    builders:
+      - shell: |
+          sudo dnf -y install ansible
+          echo "${HOSTNAME} ansible_user=${USER}" > hosts
+          export ANSIBLE_HOST_KEY_CHECKING=False
+          ansible-playbook ci/ansible/pulp_build_box.yml --extra-vars "vagrant_cloud_token=${VAGRANT_CLOUD_TOKEN}" -i hosts 
+    publishers:
+        - email-notify-owners
+        - mark-node-offline

--- a/ci/jjb/jobs/pulp-3-build-environment.yaml
+++ b/ci/jjb/jobs/pulp-3-build-environment.yaml
@@ -1,0 +1,52 @@
+- job:
+    name: pulp-3-build-environment
+    concurrent: true
+    node: 'fedora-np'
+    description: |
+      <p>
+        Prepare build environment for building Vagrant box pre-installed with Pulp 3 on the host identified by the job parameter
+        <code>HOSTNAME</code>.
+      </p>
+      <p>
+        This job requires two hosts: one for use as an Ansible control host, and
+        one on which to configure Packer and other necessary stuff. Jenkins is responsible
+        for providing the control host, and you are responsible for providing the build environment.
+        When this job is executed, Jenkins will configure the control host, by doing things 
+        like installing Ansible and configuring SSH keys. Then, the control host will reach out 
+        and configure Packer and other things onto the host identified by <code>HOSTNAME</code>.
+      </p>
+      <p>
+        Ensure the following is in <code>~/.ssh/authorized_keys</code> on the
+        Pulp 3 host:
+      </p>
+      <pre>
+        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6DJ8fmd61DWPCMiOEuy96ajI7rL3rWu7C9NQhE9a4SfyaiBcghREHJNCz9LGJ57jtOmNV0+UEDhyvTckZI2YQeDqGCP/xO9B+5gQNlyGZ9gSmFz+68NhYQ0vRekikpb9jNdy6ZZbfZDLp1w7dxqDIKfoyu7QO3Qr3E/9CpiucQif2p+oQOVOCdKEjvGYNkYQks0jVTYNRscgmcezpfLKhqWzAre5+JaMB0kRD5Nqadm2uXKZ4cNYStrpZ4xUrnMvAqjormxW2VJNx+0716Wc2Byhg8Nva+bsOkxp/GewBWHfNPtzQGMsL7oYZPtOd/LrmyYeu/M5Uz7/6QCv4N90P pulp
+      </pre>
+      <p>
+        In addition, ensure the build environment satisfies the <a
+        href="http://docs.ansible.com/ansible/latest/intro_installation.html#managed-node-requirements">managed
+        node requirements</a>.
+      </p>
+    parameters:
+      - string:
+          name: HOSTNAME
+          default: 10.13.129.54
+      - string:
+          name: USER
+          default: root 
+    properties:
+        - dev-ownership
+    scm:
+      - git:
+          url: https://github.com/pulp/pulp-ci.git
+    wrappers:
+      - jenkins-ssh-credentials
+    builders:
+      - shell: |
+          sudo dnf -y install ansible
+          echo "${HOSTNAME} ansible_user=${USER}" > hosts
+          export ANSIBLE_HOST_KEY_CHECKING=False
+          ansible-playbook ci/ansible/pulp_build_environment.yml -i hosts 
+    publishers:
+        - email-notify-owners
+        - mark-node-offline


### PR DESCRIPTION
Add a new job called "pulp-3-build-box", which
builds Vagrant boxes on an arbitrary host, over SSH,
using Packer and Ansible. Also, uploads them to
Vagrant cloud with box-name "pulp/pulpcore"
for community usage.

- [x] update welcome message using motd

closes #2908