### PR TITLE
Test f26 and f27 for pulp-3-dev-{os} jobs

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -63,8 +63,8 @@
 - project:
     name: pulp-3-dev
     os:
-        - f25
         - f26
+        - f27
     jobs:
         - pulp-3-dev-{os}
 


### PR DESCRIPTION
According to the developers, Pulp 3 currently supports Fedora 26 and
Fedora 27. Let the pulp-3-dev-{os} jobs target Fedora 26 and Fedora 27.

Also see: https://pulp.plan.io/issues/3282