### PR TITLE
Require Fedora 26 or newer for pulp-fixtures

### DIFF
--- a/ci/jjb/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jjb/jobs/pulp-fixtures-publisher.yaml
@@ -3,7 +3,7 @@
 
 - job-template:
     name: 'pulp-fixtures-publisher'
-    node: 'docker-np'
+    node: f26-np || f27-np
     properties:
         - qe-ownership
     scm:


### PR DESCRIPTION
The Pulp Fixtures project requires Bash 4.4 or newer, which is present
in Fedora 26 and newer.

The "or" syntax used by this commit can be seen here:
https://docs.openstack.org/infra/jenkins-job-builder/definition.html#job