### PR TITLE
Fix pulp-fixtures-publisher

### DIFF
--- a/ci/jjb/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jjb/jobs/pulp-fixtures-publisher.yaml
@@ -3,7 +3,7 @@
 
 - job-template:
     name: 'pulp-fixtures-publisher'
-    node: f26-np || f27-np
+    node: 'docker-np'
     properties:
         - qe-ownership
     scm:

--- a/ci/nodepool/nodepool.yaml
+++ b/ci/nodepool/nodepool.yaml
@@ -88,7 +88,7 @@ providers:
     clean-floating-ips: true
     images:
       - name: docker-np
-        base-image: Fedora-Cloud-Base-25-compose-latest
+        base-image: Fedora-Cloud-Base-26-compose-latest
         username: jenkins
         setup: prepare_node.sh
         private-key: /etc/nodepool/pulp_rsa


### PR DESCRIPTION
The first commit reverts a failed attempt at updating the pulp-fixtures-publisher job. The second commit takes another stab at it. See the commit messages for details.