### PR TITLE
Use dict.items instead of dict.iteritems

### DIFF
--- a/ci/ansible/roles/pulp/templates/yum_repo.j2
+++ b/ci/ansible/roles/pulp/templates/yum_repo.j2
@@ -1,4 +1,4 @@
 [{{ item.key }}]
-{% for key, value in item.value.iteritems() | sort -%}
+{% for key, value in item.value.items() | sort -%}
   {{ key }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
Python 2 offers both `items` and `iteritems` methods on dicts. Python 3
offers just an `items` method on dicts.