### PR TITLE
Revert "Do not install packages as root"

### DIFF
--- a/ci/jjb/jobs/unittests.yaml
+++ b/ci/jjb/jobs/unittests.yaml
@@ -136,10 +136,10 @@
 
             for setup in `find . -name setup.py`; do
                 pushd `dirname $setup`;
-                pip install -e .;
+                sudo pip install -e .;
                 popd;
             done;
-            python ./pulp-dev.py -I
+            sudo python ./pulp-dev.py -I
 
             cd $WORKSPACE/pulp
             export PYTHONUNBUFFERED=1
@@ -287,10 +287,10 @@
             cd $WORKSPACE/plugin
             for setup in `find . -name setup.py`; do
                 pushd `dirname $setup`;
-                python setup.py develop;
+                sudo python setup.py develop;
                 popd;
             done;
-            python ./pulp-dev.py -I
+            sudo python ./pulp-dev.py -I
 
             cd $WORKSPACE/plugin
             export PYTHONUNBUFFERED=1


### PR DESCRIPTION
This reverts commit 19c5a0e599d2570062bb4f09b0d93903aa0a4a92.

This fixes a permissions problem we were experiencing.

fixes #3684
https://pulp.plan.io/issues/3684