### PR TITLE
Drop hard-coded reference to /tmp/jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ install:
   - pip install ansible 'jenkins-job-builder<2'
 script:
   - ansible-playbook --syntax-check ci/ansible/*.yaml
-  - cd ci/jjb && jenkins-jobs --conf jenkins_jobs.ini test -r -o /tmp/jobs jobs
+  - cd ci/jjb && jenkins-jobs --conf jenkins_jobs.ini test -r -o "$(mktemp --directory)" jobs


### PR DESCRIPTION
The `.travis.yml` file directs Travis to create the `/tmp/jobs`
directory as part of one of its tests. This is dangerous: a file by this
name might already exist, and if it does, it shouldn't be overwritten.
Use a directory as returned by `mktemp` instead.