### PR TITLE
Let Pulp 3 JJB jobs reference correct branch

### DIFF
--- a/ci/jjb/jobs/pulp-3-installer.yaml
+++ b/ci/jjb/jobs/pulp-3-installer.yaml
@@ -45,8 +45,6 @@
     scm:
       - git:
           url: https://github.com/pulp/devel.git
-          branches:
-            - '3.0-dev'
           skip-tag: true
     wrappers:
       - jenkins-ssh-credentials

--- a/ci/jjb/jobs/pulp-3-pypi.yaml
+++ b/ci/jjb/jobs/pulp-3-pypi.yaml
@@ -16,8 +16,6 @@
     scm:
       - git:
           url: https://github.com/pulp/devel.git
-          branches:
-            - '3.0-dev'
           skip-tag: true
     triggers:
         - timed: "H 2 * * *"


### PR DESCRIPTION
The pulp/devel repository has been updated. Formerly, Pulp 2 was
available via the "master" branch, and Pulp 3 was available via the
"3.0-dev" branch. Now, Pulp 2 is available via the "2-master" branch,
and Pulp 3 is available via the "master" branch.