### PR TITLE
Fips installer

### DIFF
--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -4,6 +4,10 @@
   roles:
     - role: subscription-manager
       when: ansible_distribution == 'RedHat'
+    - role: pulp-fips
+      when:
+        - enable_fips is defined
+        - enable_fips
     - role: pulp
     - role: lazy
       when: pulp_version | version_compare('2.8', '>=')

--- a/ci/ansible/roles/pulp-fips/README.md
+++ b/ci/ansible/roles/pulp-fips/README.md
@@ -1,0 +1,20 @@
+pulp-fips
+=========
+
+Enable FIPS on a RHEL 7 (or CentOS 7) host.
+
+When executed, this role will do the following:
+
+1. Install packages needed for FIPS support. If needed, generate a new
+   initramfs.
+2. Make GRUB pass a FIPS-enablement flag to the kernel at boot time. If needed,
+   also generate a new GRUB configuration and restart the host.
+3. Assert that FIPS is supported and enabled.
+
+No variables are supported. Sample usage within a playbook:
+
+```yaml
+- hosts: all
+  roles:
+    - role: pulp-fips
+```

--- a/ci/ansible/roles/pulp-fips/handlers/main.yml
+++ b/ci/ansible/roles/pulp-fips/handlers/main.yml
@@ -1,0 +1,17 @@
+- name: Generate initramfs
+  command: dracut -f
+  become: true
+
+- name: Restart host
+  shell: sleep 5 && systemctl reboot
+  async: 1
+  poll: 0
+  ignore_errors: true
+  become: true
+
+- name: Wait for host to become available
+  wait_for_connection:
+    delay: 30
+    timeout: 300
+    connect_timeout: 20
+    sleep: 5

--- a/ci/ansible/roles/pulp-fips/tasks/configure-grub.yml
+++ b/ci/ansible/roles/pulp-fips/tasks/configure-grub.yml
@@ -1,0 +1,29 @@
+# Example: GRUB_CMDLINE_LINUX="crashkernel=auto rd.lvm.lv=rhel/root quiet ..."
+- name: Enable FIPS at boot
+  lineinfile:
+    path: /etc/default/grub
+    backrefs: true
+    regexp: '^(GRUB_CMDLINE_LINUX=")(.*")'
+    line: '\1fips=1 boot=UUID={{ (ansible_mounts | selectattr("mount", "equalto", "/boot") | list)[0]["uuid"] }} \2'
+  become: true
+
+- name: Check whether system was booted in EFI mode
+  stat:
+    path: /sys/firmware/efi
+  register: result
+
+- name: Make grub2 config in BIOS mode
+  command: grub2-mkconfig -o /etc/grub2.cfg
+  become: true
+  when: result.stat.exists == false
+  notify:
+  - Restart host
+  - Wait for host to become available
+
+- name: Make grub2 config in EFI mode
+  command: grub2-mkconfig -o /etc/grub2-efi.cfg
+  become: true
+  when: result.stat.exists == true
+  notify:
+  - Restart host
+  - Wait for host to become available

--- a/ci/ansible/roles/pulp-fips/tasks/main.yml
+++ b/ci/ansible/roles/pulp-fips/tasks/main.yml
@@ -1,0 +1,42 @@
+- name: Install the dracut FIPS package
+  yum:
+    name: dracut-fips
+    state: present
+  become: true
+  notify: Generate initramfs
+
+- name: Get CPU information
+  slurp:
+    src: /proc/cpuinfo
+  register: result
+
+- name: Install dracut AES
+  yum:
+    name: dracut-fips-aesni
+    state: present
+  become: true
+  when: '"aes" in result["content"] | b64decode'
+  notify: Generate initramfs
+
+- name: Get the options grub passes to the kernel at boot
+  command: bash -c 'source /etc/default/grub && echo "$GRUB_CMDLINE_LINUX"'
+  changed_when: false
+  check_mode: false
+  register: result
+
+# This "when" is only applied to this "include_tasks" task, not to all of the
+# tasks in the included file. See:
+# https://docs.ansible.com/ansible/2.4/playbooks_reuse.html
+- include_tasks: configure-grub.yml
+  when: not ("fips" in result.stdout)
+
+- meta: flush_handlers
+
+- name: Check whether FIPS is supported
+  slurp:
+    src: /proc/sys/crypto/fips_enabled
+  register: result
+
+- name: Assert that FIPS is enabled
+  assert:
+    that: (result["content"] | b64decode).strip() == '1'


### PR DESCRIPTION
This PR is to add a Ansible job for enabling FIPS in a remote VM. This fix is meant for local usage and not to be included in jenkins as the script involves reboot of the VM( which is unsupported by jenkins slave).
The FIPS installer works as a part of PULP setup, where the machine is FIPS enabled when called with the command line argument `enable_fips=True`
