### PR TITLE
Added qpid SSL setup tasks

### DIFF
--- a/ci/ansible/roles/pulp-certs/README.md
+++ b/ci/ansible/roles/pulp-certs/README.md
@@ -1,0 +1,19 @@
+# Pulp Certs
+
+This role creates the CA and sets the SSL certificates for Pulp in Apache and Qpid.
+
+The location of certs is: `/etc/pki`
+
+## Main task
+
+The `main.yml` tasks creates the main CA in `/etc/pki/CA` and sets the certificates for Apache server
+
+
+## Qpid SSL
+
+The `qpid.yml` tasks creates the qpid NSS database ans sets up the certificates for
+broker and client using `certutil` command line.
+
+After the certificates are generated the config files `/etc/qpid/qpidd.conf` and `/etc/pulp/server.conf` are updated with SSL configuration.
+
+After all tasks the services `httpd, pulp_workers, pulp_celerybeat, pulp_resource_maneger and qpidd` are restarted.

--- a/ci/ansible/roles/pulp-certs/handlers/main.yaml
+++ b/ci/ansible/roles/pulp-certs/handlers/main.yaml
@@ -1,0 +1,12 @@
+---
+- name: Restart all services
+  loop:
+    - httpd
+    - pulp_workers
+    - pulp_celerybeat
+    - pulp_resource_manager
+    - qpidd
+  service:
+    name: "{{ item }}"
+    state: restarted
+  

--- a/ci/ansible/roles/pulp-certs/tasks/main.yml
+++ b/ci/ansible/roles/pulp-certs/tasks/main.yml
@@ -60,7 +60,6 @@
     chdir: /etc/pki/tls/
     creates: certs/apachecert.pem
 
-# In the distant future when Ansible sets everything up, this should notify httpd
 - name: Configure Apache TLS certificate
   lineinfile:
     backrefs: yes
@@ -74,3 +73,10 @@
     dest: /etc/httpd/conf.d/ssl.conf
     regexp: '^SSLCertificateKeyFile '
     line: 'SSLCertificateKeyFile /etc/pki/tls/private/apachekey.pem'
+
+- name: Configure QPID SSL
+  import_tasks: qpid.yml
+
+-  debug: msg="trigger services restart"
+   notify: Restart all services
+   changed_when: true

--- a/ci/ansible/roles/pulp-certs/tasks/qpid.yml
+++ b/ci/ansible/roles/pulp-certs/tasks/qpid.yml
@@ -1,0 +1,246 @@
+---
+- name: create temporary working directory
+  tempfile:
+    state: directory
+  register: temp_dir
+
+- set_fact:
+    # when passing `-i root@hostname,` removes the `root@`
+    hostname: "{{ inventory_hostname.rpartition('@')[-1] }}"
+    tempdir: "{{ temp_dir.path }}"
+
+- set_fact:
+    instdir: "/etc/pki/qpid"
+    clientdir: "{{ tempdir }}/client"
+    pwdfile: "{{ tempdir }}/password"
+    seedfile: "{{ tempdir }}/seed"
+    valid: 12
+    ca_path: "/etc/pki/pulp/ca.crt"
+    ca_key_path: "/etc/pki/pulp/ca.key"
+    ca_name: "ca"
+    db_password: "pulp"
+    trust: "TCu,Cu,Tuw"
+    client_subject: "CN=client,O=pulp,ST=North Carolina,C=US"
+    client_nickname: "client"
+    broker_subject: "CN={{ hostname }},O=pulp,ST=North Carolina,C=US"
+    broker_nickname: "broker"
+
+# SETUP BASE NSS db and Certs
+
+- name: Create the password file
+  lineinfile:
+    dest: "{{ pwdfile }}"
+    line: "{{ db_password }}"
+    create: yes
+
+- name: Create the main NSS db
+  command: certutil -N -d {{ tempdir }} --empty-password
+  args:
+    creates: "{{ tempdir }}/cert8.db"
+
+- name: Generates the p12 certificate file
+  command: >
+    openssl pkcs12 -export -in {{ ca_path }} -inkey {{ ca_key_path }}
+    -out {{ tempdir }}/ca.p12 -name "{{ ca_name }}" -password file:{{ pwdfile }}
+  args:
+    creates: "{{ tempdir }}/ca.p12"
+
+- name: Import the p12 file to nss database
+  command: >
+    pk12util -d {{ tempdir }} -n "{{ ca_name }}" -i {{ tempdir }}/ca.p12
+    -w {{ pwdfile }}
+
+- name: Modify the Trust attributes to the certificate
+  command: >
+    certutil -d {{ tempdir }} -n "{{ ca_name }}" -M -t "{{ trust }}"
+
+- name: Output ca certificate to ca.crt file
+  command: >
+    certutil -L -d {{ tempdir }} -n "{{ ca_name }}" -a 
+    -o {{ tempdir }}/ca.crt
+  args:
+    creates: "{{ tempdir }}/ca.crt"
+
+# BROKER CERT
+
+- name: Seed the seed file
+  command: dd if=/dev/urandom of={{ seedfile }} bs=8192 count=1
+
+- name: Create broker cert signing request
+  command: >
+    certutil -R -d {{ tempdir }} -s {{ broker_subject }} -a
+    -o {{ tempdir }}/broker.req -z {{ seedfile }}
+
+- name: Sign the broker cert w/ CA
+  command: >
+    certutil -C -d {{ tempdir }} -c "{{ ca_name }}" -v {{ valid }} 
+    -uV -m1 -a -i {{ tempdir }}/broker.req -o {{ tempdir }}/broker.crt
+
+- name: Import the broker cert
+  command: >
+    certutil -A -d {{ tempdir }} -n "{{ broker_nickname }}" -t ",,"
+    -a -i {{ tempdir }}/broker.crt
+
+# CLIENT CERT
+
+- name: Create client db directory
+  file:
+    path: "{{ clientdir }}"
+    state: directory
+
+- name: Create client nss db
+  command: certutil -N -d {{ clientdir }} --empty-password
+  args:
+    creates: "{{ clientdir }}/cert8.db"
+
+- name: Seed the seed file
+  command: dd if=/dev/urandom of={{ seedfile }} bs=8192 count=1
+
+- name: Create client cert signing request
+  command: >
+    certutil -R -d {{ clientdir }} -s {{ client_subject }} -a 
+    -o {{ tempdir }}/client.req -z {{ seedfile }}
+
+- name: Sign the client cert w/ CA
+  command: >
+    certutil -C -d {{ tempdir }} -c "{{ ca_name }}" -v {{ valid }} 
+    -uC -m2 -a -i {{ tempdir }}/client.req -o {{ tempdir }}/tmp_client_cert.crt
+  args:
+    creates: "{{ tempdir }}/tmp_client_cert.crt"
+
+- name: Import the client cert
+  command: >
+    certutil -A -d {{ clientdir }} -n "{{ client_nickname }}" -t ",,"
+    -a -i {{ tempdir }}/tmp_client_cert.crt
+
+- name: Export client p12
+  command: >
+    pk12util -d {{ clientdir }} -n "{{ client_nickname }}" 
+    -o {{ tempdir }}/client.p12 -w {{ pwdfile }} -W {{ db_password }}
+  args:
+    creates: "{{ tempdir }}/client.p12" 
+
+- name: Generates a new client key & cert
+  command: >
+    openssl pkcs12 -in {{ tempdir }}/client.p12 -nodes 
+    -out {{ tempdir }}/client.crt -password file:{{ pwdfile }}
+  args:
+    creates: "{{ tempdir }}/client.crt"
+
+# Install the certs to the destination directory
+
+- name: Create target directory
+  file:
+    path: "{{ instdir }}"
+    state: directory
+    mode: "755"
+    owner: root
+    group: apache
+  
+- name: Create nss db dir
+  file:
+    path: "{{ instdir }}/nss"
+    state: directory
+    mode: "755"
+    owner: root
+    group: qpidd
+
+- name: Find crt files to copy
+  find:
+    paths: "{{ tempdir }}"
+    patterns: '*.crt'
+  register: crtfind
+
+- name: Copy crt files
+  copy:
+    remote_src: yes
+    src: "{{ item.path }}"
+    dest: "{{ instdir }}/"
+    owner: root
+    group: apache
+    mode: "640"
+  loop: "{{ crtfind.files }}"
+
+- name: Find nss db and password files to copy
+  find:
+    paths: "{{ tempdir }}"
+    patterns: '*.db,password'
+  register: nssfind
+
+- name: Copy nss database and password file
+  copy:
+    remote_src: yes
+    src: "{{ item.path }}"
+    dest: "{{ instdir }}/nss/"
+    owner: root
+    group: qpidd
+    mode: "640"
+  loop: "{{ nssfind.files }}"
+
+- debug:
+      var: tempdir
+
+# WRITE CONFIG FILES
+
+# qpid CONFIG
+
+- name: Disable qpidd.conf auth
+  lineinfile:
+    path: /etc/qpid/qpidd.conf
+    regexp: '^auth=yes$'
+    line: 'auth=no'
+    backrefs: yes
+
+- name: Write qpidd.conf block
+  blockinfile:
+    path: /etc/qpid/qpidd.conf
+    insertafter: "auth=no"
+    # marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    block: | 
+      require-encryption=yes
+      ssl-require-client-authentication=yes
+      ssl-cert-db={{ instdir }}/nss
+      #ssl-cert-password-file={{ instdir }}/nss/password
+      ssl-cert-name=broker
+      ssl-port=5671
+    
+# Pulp CONFIG
+
+- name: Comment out existing messaging section
+  lineinfile:
+    path: /etc/pulp/server.conf
+    regexp: '^\[messaging\]$'
+    line: '# [messaging]'
+    backrefs: yes
+
+- name: Write [messaging] block
+  blockinfile:
+    path: /etc/pulp/server.conf
+    insertbefore: "# = Asynchronous Tasks ="
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - messaging"
+    block: |
+      [messaging]
+      url: ssl://{{ hostname }}:5671
+      cacert: {{ ca_path }}
+      clientcert: {{ instdir }}/client.crt
+
+- name: Comment out existing tasks section
+  lineinfile:
+    path: /etc/pulp/server.conf
+    regexp: '^\[tasks\]$'
+    line: '# [tasks]'
+    backrefs: yes
+
+- name: Write [tasks] block
+  blockinfile:
+    path: /etc/pulp/server.conf
+    insertbefore: "# = Email ="
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - tasks"
+    block: |
+      [tasks]
+      broker_url: qpid://{{ hostname }}:5671/
+      celery_require_ssl: true
+      cacert: {{ ca_path }}
+      keyfile: {{ instdir }}/client.crt
+      certfile: {{ instdir }}/client.crt
+...


### PR DESCRIPTION
- Added as a sub-task of pulp-certs role
- Added handlers to restart all the services
- Used `command:` module instead of openssl or certutil module
- Used `blockinfile` to write config files relying on pre-existence
  of config files for qpid and pulp

Pending

- [x] Use --empty-password for FIPS
- [x] Testing in FIPS environment

Tested:

- Fedora 26
- Fedora 27
- RHEL 7.5
- RHEL 7.5 with FIPS enabled