### PR TITLE
Use package module instead of action module

### DIFF
--- a/ci/ansible/roles/subscription-manager/tasks/main.yaml
+++ b/ci/ansible/roles/subscription-manager/tasks/main.yaml
@@ -60,4 +60,6 @@
   when: ansible_distribution_major_version|int >= 7
 
 - name: Enable EPEL repository
-  action: "{{ ansible_pkg_mgr }} name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+  package:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+    state: present


### PR DESCRIPTION
The "package" module is well-documented and well-understood. Action
plugins are a more advanced feature. Why use an advanced feature when a
more well-understood feature will do?

As a bonus, the resulting code is in standard YAML syntax, instead of
being a single long string that must be interpreted by Ansible.