### PR TITLE
Update Pulp Smash config file for Pulp 3 tests

### DIFF
--- a/ci/jjb/scripts/pulp-3-devel-smasher.sh
+++ b/ci/jjb/scripts/pulp-3-devel-smasher.sh
@@ -15,21 +15,18 @@ cat >~/.config/pulp_smash/settings.json <<EOF
 {
     "pulp": {
         "auth": ["admin", "admin"],
+        "selinux enabled": false,
         "version": "3"
     },
     "hosts": [
         {
             "hostname": "$(hostname --long)",
             "roles": {
-                "amqp broker": {"service": "qpidd"},
-                "api": {"port": 8000, "scheme": "http"},
-                "mongod": {},
-                "pulp celerybeat": {},
-                "pulp cli": {},
+                "api": {"port": 8000, "scheme": "http", "service": "nginx"},
                 "pulp resource manager": {},
                 "pulp workers": {},
-                "shell": {},
-                "squid": {}
+                "redis": {},
+                "shell": {}
             }
         }
     ]

--- a/ci/jjb/scripts/pulp-3-pypi-smasher.sh
+++ b/ci/jjb/scripts/pulp-3-pypi-smasher.sh
@@ -8,21 +8,18 @@ cat >~/.config/pulp_smash/settings.json <<EOF
 {
     "pulp": {
         "auth": ["admin", "admin"],
+        "selinux enabled": false,
         "version": "3"
     },
     "hosts": [
         {
             "hostname": "$(hostname --long)",
             "roles": {
-                "amqp broker": {"service": "rabbitmq"},
-                "api": {"port": 8000, "scheme": "http"},
-                "mongod": {},
-                "pulp celerybeat": {},
-                "pulp cli": {},
+                "api": {"port": 8000, "scheme": "http", "service": "nginx"},
                 "pulp resource manager": {},
                 "pulp workers": {},
-                "shell": {},
-                "squid": {}
+                "redis": {},
+                "shell": {}
             }
         }
     ]


### PR DESCRIPTION
For some time, the same kind of Pulp Smash configuration file would work
whether testing Pulp 2 or 3. Semantically, though, this makes no sense:
one could create a configuration file declaring that a host running Pulp
3 fulfilled the "pulp celerybeat" role, despite this not being true.

This has been fixed, and the definition of what constitutes a valid Pulp
Smash configuration file has changed. Users who are testing Pulp 3 need
to update their configuration files. Do so for the Pulp 3 jobs in
Jenkins.

See:

* https://github.com/PulpQE/pulp-smash/issues/965
* https://github.com/PulpQE/pulp-smash/pull/1101