### PR TITLE
Let pulp-smash-runner job give debug info

### DIFF
--- a/ci/jjb/jobs/pulp-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp-smash-runner.yaml
@@ -68,6 +68,9 @@
         - timestamps
     builders:
         - shell: |
+            # Useful for debugging
+            getent passwd "$(id -u)"
+
             # Setup ssh config and private key
             mkdir ~/.ssh/controlmasters
             if [ -f SSH_CUSTOM_CONFIG ]; then


### PR DESCRIPTION
This will help solve a current test runner failure, and help with
debugging future test runner failures.