### PR TITLE
Escalate privileges as needed in pulp_2_tests.yaml

### DIFF
--- a/ci/ansible/pulp_2_tests.yaml
+++ b/ci/ansible/pulp_2_tests.yaml
@@ -1,3 +1,4 @@
 - hosts: all
+  become: false
   roles:
   - pulp-2-tests


### PR DESCRIPTION
The `pulp-2-tests` role correctly becomes other users as needed. Ensure
that the playbook which calls it respects this good behaviour.