### PR TITLE
Don't install Pulp Smash from source

### DIFF
--- a/ci/ansible/roles/pulp-2-tests/tasks/main.yml
+++ b/ci/ansible/roles/pulp-2-tests/tasks/main.yml
@@ -67,12 +67,6 @@
     state: latest
   when: result is changed
 
-- name: Install Pulp Smash
-  pip:
-    virtualenv: '{{ ansible_user_dir }}/.virtualenvs/pulp-2-tests'
-    name: git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
-    state: present
-
 - name: Install Pulp 2 Tests
   pip:
     virtualenv: '{{ ansible_user_dir }}/.virtualenvs/pulp-2-tests'


### PR DESCRIPTION
The pulp-2-tests role installs Pulp 2 Tests. Pulp 2 Tests depends on a
specific range of Pulp Smash versions, and thus will pull in the correct
version as needed. As a result, installing Pulp Smash directly from git
an unnecessary extra step. In fact, installing Pulp Smash from source is
harmful: it prevents us from verifying that Pulp 2 Test's dependencies
are correctly specified.

See: https://github.com/PulpQE/Pulp-2-Tests/pull/3