### PR TITLE
Adding disk image builder jobs for building opensstack images

### DIFF
--- a/ci/jjb/jobs/disk-image-builder.yaml
+++ b/ci/jjb/jobs/disk-image-builder.yaml
@@ -1,0 +1,20 @@
+- job-template:
+    name: 'disk-image-builder-base'
+    node: 'disk-image-builder'
+    properties:
+        - qe-ownership
+    scm:
+        - pulp-ci-github
+    wrappers:
+        - config-file-provider:
+            files:
+                - file-id: rhn_credentials
+                  variable: RHN_CREDENTIALS
+                - file-id: Open_Stack_Credentials
+                  variable: Open_Stack_Credentials
+
+    builders:
+        - shell:
+            !include-raw-escape:
+                - 'disk-image-builder.sh'
+

--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -67,6 +67,11 @@
     - pulp-{build_version}-dev-{os}
 
 - project:
+    name: disk-image-builder-base
+    jobs:
+        - disk-image-builder-base
+
+- project:
     name: pulp-3-pypi
     os:
     - f27

--- a/ci/jjb/scripts/disk-image-builder.sh
+++ b/ci/jjb/scripts/disk-image-builder.sh
@@ -1,0 +1,8 @@
+touch ./env_variables.sh
+chmod +x ./env_variables.sh
+cat "${RHN_CREDENTIALS}" >> ./env_variables.sh
+cat "${Open_Stack_Credentials}" >> ./env_variables.sh
+rm -rf ~/.venvs/openstack/
+virtualenv ~/.venvs/openstack/
+source ~/.venvs/openstack/bin/activate
+./ci/open_stack_plugin/disk_image_builder/scripts/builder.sh all

--- a/ci/open_stack_plugin/disk_image_builder/README.md
+++ b/ci/open_stack_plugin/disk_image_builder/README.md
@@ -1,0 +1,290 @@
+# diskimage-builder Notes
+
+## Contents:
+
+* What is diskimage-builder + how to install
+* What are elements
+* Creating new elements
+* Interacting with the elements
+* Phases involved in Disk image builder
+* Using elements
+* Jenkins CI and OpenStack
+* Builder Script ( Skip to this section for using scripts straight away for building images)
+
+
+## What is diskimage-builder + how to install
+
+The [diskimage-builder](https://docs.openstack.org/diskimage-builder/latest/)
+project provides tooling to allow creation of `qcow2` images and allows the
+user to combine any number of "elements" to create a custom image.  Elements
+allow reuse of common image creation tasks. If you are familar with ansible
+"roles", diskimage-builder elements are kind of like that.
+First, you need to set up your environment and install diskimage-builder.
+
+Currently diskimage-builder has a bug that prevents use of virtual environments
+created with `python3 -m venv path/to/new/venv` (see:
+https://bugs.launchpad.net/diskimage-builder/+bug/1745626 ). For this reason I
+will show installing into a python2.7 virtual environment.
+
+```
+python2.7 -m virtualenv ~/envs/dibenv
+source ~/envs/dibenv/bin/activate
+pip install diskimage-builder
+```
+
+Additionally you need some tools that should be available from your package manager.
+For example, on Fedora 26, I was able to install the following:
+
+```
+dnf install qemu-img yum-utils
+```
+
+This list may not be exhaustive, as the machines this workflow has been tested
+on also have been set up with all necessary to run kvm based virtualization.
+
+## What are elements
+
+When you run the `disk-image-create` command, you provide a list of "elements"
+that define how the image will be created. These Elements can either be user defined
+(As in this case the Jenkins-slave element) and Open stack Elements.Elements define tasks to be done at
+each of the "phases" of image creation. Each phase has a directory in the
+"element" directory. The [phase
+documentation](https://docs.openstack.org/diskimage-builder/latest/developer/developing_elements.html#phase-subdirectories)
+shows the name of the phases and the order in which they are executed. An
+element need only include directory for the phases in which it needs to execute
+scripts.
+
+Also not every phase runs on the image(chroot) that is being build. Some of the phases :
+root.d, extra-data.d, block-device.d,cleanup.d runs on the local machine,
+while the other phases runs on the machine that is being build.
+
+If you use multiple elements and they all have the `install.d` phase directory
+defined, then all the scripts found in each element's `install.d` directory
+run. The order in which they run is determined by sorting the scripts based on
+the name of the script. This is the rational to why the scripts you find in all
+example elements have numbers in front of the name. For example if `element1`
+has a script named `22-do-this-thing`, then it will run before `element2`'s
+script named `23-do-the-other-thing`.
+
+All elements found in
+https://github.com/openstack/diskimage-builder/tree/master/diskimage_builder/elements
+ship with diskimage-builder and can be used simply by specifying the name.
+
+## Creating new elements
+
+Documentation for developers wanting to create their own custom elements can be
+found on the OpenStack docs for diskimage-builder:
+https://docs.openstack.org/diskimage-builder/latest/developer/developing_elements.html
+
+One way to start working on a new element is to template it after existing
+[elements packaged with diskimage-builder
+itself](https://github.com/openstack/diskimage-builder/tree/master/diskimage_builder/elements)
+
+The name of the top directory of the element is the name of the element.
+Create directories for each
+[phase](https://docs.openstack.org/diskimage-builder/latest/developer/developing_elements.html#phase-subdirectories)
+you want to execute scripts during.
+Below are some extra notes about the phases we are currently using in this element. They are listed in the order in which they execute. Exhaustive list of [phases can be found in the OpenStack docs](https://docs.openstack.org/diskimage-builder/latest/developer/developing_elements.html#phase-subdirectories).
+
+## Interacting with the elements
+
+Customizing the image to your needs is done with the help of variables. All the variables that are required for the elements
+are exported as environment variables before building the image using the diskimage builder.
+
+for example: The bootloader element that steps up grub on the boot partition that allows setting up boot variables. This can be achieved by
+exporting the DIB_BOOTLOADER_DEFAULT_CMDLINE with the key-value boot variable pairs.
+
+## Phases involved in Disk image builder
+
+### extra-data.d
+
+This phase is when we can copy items from the local filesystem into the image
+filesystem.  For example we copy the jenkins sshkey into the image in
+[`elements/jenkins-slave/extra-data.d/20-jenkins-slave`](https://github.com/quipucords/ci/blob/ed1d9d040bcfc6bca9543fd1b528e036983772ed/ansible/roles/nodepool/files/elements/jenkins-slave/extra-data.d/20-jenkins-public-ssh-key#L7)
+
+### install.d
+
+This phase runs scripts after the OS is provisioned For example, we create the
+jenkins user in 
+[`elements/jenkins-slave/install.d/20-jenkins-slave`](https://github.com/quipucords/ci/blob/ed1d9d040bcfc6bca9543fd1b528e036983772ed/ansible/roles/nodepool/files/elements/jenkins-slave/install.d/20-jenkins-slave#L7).
+
+### How to define dependencies on other elements for an element
+
+Place a file named `element-deps` in base directory of the element. It is
+newline seperated list where you name the elements you depend on.  You can
+specify custom elements or built in elements from disk image builder. Custom
+elements can be used by diskimage-builder if they are located in a directory
+pointed to by the environment variable `$ELEMENTS_PATH`.
+
+> Note: It remains to be seen if there is precedence if there is namespace clash.
+
+### How to install packages after the OS provisioned:
+
+If you depend on the use the package-installs element so you don't have to
+reinvent lots of logic about differnt package managers. Then you can create
+`package-installs.yaml` in the base directory of your element. It can be as
+simple as our current
+[`package-installs.yaml`](https://github.com/quipucords/ci/blob/ed1d9d040bcfc6bca9543fd1b528e036983772ed/ansible/roles/nodepool/files/elements/jenkins-slave/package-installs.yaml#L1)
+or more complicated, including some logic after the name of the package if the
+package name differs based on the OS. Example of this is shown in this README:
+https://github.com/openstack/diskimage-builder/tree/master/diskimage_builder/elements/package-installs#package-installs.
+
+
+## Using elements
+
+You can use elements either by depending on them in the `element-deps` file or
+by including them in arguments to `diskimage-builder-create`.  Before you use
+an element, you should look through it to see if the element needs any
+environment variables!
+There is no method to pass command line arguments to the elements at the invocation of diskimage-builder-create to the elements, so all configuration is done by environment variables.
+
+
+### Special variables
+
+All variables that start with `$DIB_*` are special environment variables used by
+the diskimage-builder built in elements.
+
+### Building Our Images
+
+We use the following elements for fedora images:
+
+ element        | description
+ ---------------| ---------------------------
+ fedora-minimal | DIB built in. says we want a fedora machine. Needs DIB_RELEASE to decide what version to use
+ vm             | DIB built in. Sets up a partitioned disk (rather than building just one filesystem with no partition table).
+ simple-init    | DIB built in. Network and system configuration that cannot be done until boot time
+ growroot       | DIB built in. Grow the root partition on first boot.
+ jenkins-slave  | Custom defined element found in this repo.
+
+We use the following elements for CentOS images:
+
+ element        | description
+ ---------------| ---------------------------
+ centos7        | DIB built in. Needs DIB_RELEASE to decide what version to use
+ vm             | DIB built in. Sets up a partitioned disk (rather than building just one filesystem with no partition table).
+ simple-init    | DIB built in. Network and system configuration that cannot be done until boot time
+ growroot       | DIB built in. Grow the root partition on first boot.
+ epel           | DIB built in.
+ jenkins-slave  | Custom defined element found in this repo.
+
+We use the following elements for Rhel images:
+
+ element        | description
+ ---------------| ---------------------------
+ rhel7          | DIB built in. Provides the base image for building rhel images. Needs DIB_LOCAL_IMAGE which points to the base image location(qcow2 images)
+ rhel-common    | DIB built in. Takes case of rhel subscription manager.Needs REG_USER,REG_PASSWORD,REG_POOL_ID for subscription.
+ vm             | DIB built in. Sets up a partitioned disk (rather than building just one filesystem with no partition table).
+ simple-init    | DIB built in. Network and system configuration that cannot be done until boot time
+ growroot       | DIB built in. Grow the root partition on first boot.
+ jenkins-slave  | Custom defined element found in this repo.
+ bootloader     | DIB built in. Installs grub2 on boot partition. Used for setting boot parameters. Needs DIB_BOOTLOADER_DEFAULT_CMDLINE for boot variables
+ epel           | DIB built in. For Extra packages
+
+## Jenkins CI and OpenStack
+
+An user jenkins with password jenkins is configured as a sudo user in the image, during the install.d phase of the element. This makes the image instances accesible
+with usernames and password.
+
+For jenkins to access this image's instance, ssh public keys of jenkins needs to be passed to the image. This could be specified in JENKINS_PUBLIC_SSH_KEY_PATH.
+The JENKINS_PUBLIC_SSH_KEY_PATH should point to id_rsa.pub file containing jenkins public keys, which should be present in the host machine.
+
+### Uploading to OpenStack(Manual Way)
+
+1) Log into our shared OpenStack instance.
+2) Under the "compute" tab, navigate to "Images"
+3) There is a button near the search bar with a plus sign labeled "+ create image"
+4) Name the image something reasonable. Confer with other team members.
+   This is what jenkins will know the image by.
+
+### Configuring Jenkins to use your image
+
+Under `Manage Jenkins> Configure System` Find the `Cloud > Cloud (OpenStack)`
+section.  Create a new template by clicking `Add template`.
+
+The `label` is important -- it is what the jenkins jobs will specify to Jenkins
+to tell it what node to use.  Under `Advanced` options, change the `Boot
+Source` to `Image`. A new drop down will appear and will populate with names of
+images available on the OpenStack instance that the cloud is configured to talk
+to. Select the name of the image you uploaded.
+
+
+### Alternate Workflow
+
+If you cannot obtain the base image you need to use diskimage-builder, there is
+a way to customize images based off of images allready present on OpenStack.
+
+### To create image from snapshot on Openstack
+
+Under `Compute>Instances` create instance with `Launch Instance` Specify you
+public key so you will be able to ssh into the machine.  Then associate a
+floating IP to the image and log into it and do any necessary set up.
+
+After done, shut down the instance. Look under `Compute>Volumes` and see
+what volume is associated with it. May need to make a note of this as it as a
+long UUID like name.
+
+Then you can go back to the instance and delete it. This won't delete the
+volume, which is what we want.  Then under `Compute>Volumes` next to volume,
+click down arrow and click `Upload to Image`. Name it something sensible, as
+this is what Jenkins will know it by.  Choose the QCOW2 file format.
+
+Configuring Jenkins to use this image is the same as images created with
+ `diskimage-builder`.
+
+## Builder Script
+
+There is a bash script written that automates this entire process, which can be found under
+`ci/open_stack_plugin/disk_image_builder/scripts/builder.sh`.
+
+The script currently supports building two types of images
+* Rhel7 (Fips and non-Fips images)
+* Fedora-27
+
+To run the script to create all images
+run `./builder.sh all`
+
+The script can also be used for building a particular type of image if necessary by
+```bash
+# For building Fedora 27 Images alone
+source builder.sh && build_fedora_images
+
+# For building Rhel 7 Images alone
+source builder.sh && build_rhelos_images
+
+# For building Rhel 7 Images in FIPS mode
+source builder.sh && build_rhel_fips_images
+```
+
+The Base images that is used for building these images should be configured under
+`ci/open_stack_plugin/disk_image_builder/scripts/base_image_config.sh`.
+
+### Uploading Images in OpenStack
+
+The builder script also takes responsibility to upload the customized images into openstack.
+For this to happen the following parameters should be set in the system.
+
+```bash
+export OS_AUTH_URL="..."
+export OS_TENANT_NAME="..."
+export OS_USERNAME="..."
+export OS_PASSWORD=".."
+export OS_TENANT_ID="..."
+```
+
+The images gets deleted in the local machine by default
+```bash
+#export this variable to hold the images in the local
+export PERSIST_IMAGES=true
+```
+
+For Building Rhel images,the following parameters should be set in the environment in which the builder
+script is called
+
+ ```bash
+export RHN_USERNAME="..."
+export RHN_PASSWORD="..."
+export RHN_SKU_POOLID="..."
+```
+
+
+These commands can also be present in a file `env_variables.sh` in the `$PWD` where the script is run from.

--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/element-deps
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/element-deps
@@ -1,0 +1,2 @@
+openssh-server
+package-installs

--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/extra-data.d/20-jenkins-public-ssh-key
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/extra-data.d/20-jenkins-public-ssh-key
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This script runs on the host machine in which the disk image builder is running 
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+set -euo pipefail
+
+echo "JENKINS ssh key path $JENKINS_PUBLIC_SSH_KEY_PATH"
+echo "JENKINS ssh key real path "
+echo "$(realpath $JENKINS_PUBLIC_SSH_KEY_PATH)"
+JENKINS_PUBLIC_SSH_KEY_PATH="${JENKINS_PUBLIC_SSH_KEY_PATH:-/home/jenkins/.ssh/id_rsa.pub}"
+
+if [ ! -f "${JENKINS_PUBLIC_SSH_KEY_PATH}" ]; then
+    die "Can not find the public key for the jenkins user."
+fi
+
+# TMP_HOOKS_PATH is the shared directory whose files get copied to the image being build.
+cp "${JENKINS_PUBLIC_SSH_KEY_PATH}" "${TMP_HOOKS_PATH}/jenkins-public-ssh-key"

--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/finalise.d/58-setboot
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/finalise.d/58-setboot
@@ -1,0 +1,14 @@
+#!/bin/bash
+# This script will set the boot parameters for FIPS image building
+# This script will get the UUID of the boot filesystem and append that information with the fips flag to the
+# bootloader commandline for FIPS to be enabled.
+
+IS_FIPS=${IS_FIPS:-false}
+if [ "${IS_FIPS}" = true ];then
+    echo "Setting up Fips environment"
+    dracut --force
+    boot_dev=$(df /boot --output=source |tail -n+2)
+	uuid_dev=$(blkid $boot_dev -o export |grep -i UUID)
+	grubby --update-kernel=DEFAULT --args="boot=${uuid_dev}"
+fi
+

--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/install.d/21-bootstrap
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/install.d/21-bootstrap
@@ -1,0 +1,73 @@
+#!/bin/bash
+# This script runs inside the image being build.
+set -exuo pipefail
+
+# Use /etc/os-release if available or fallback to Python in order to collect
+# the DISTRIBUTION and DISTRIBUTION_MAJOR_VERSION information.
+if [ -f /etc/os-release ]; then
+    source /etc/os-release
+
+    if [ -z "${ID}" ] || [ -z "${VERSION_ID}" ]; then
+        echo "ID and VERSION_ID not set in /etc/os-release"
+        return 1
+    fi
+
+    # set DISTRIBUTION based on ID: If it's rhel or centos,
+    # make it the common "redhat". Otherwise, use ID directly.
+    # For our purposes, this means it should either be "redhat" or "fedora".
+    if [[ $ID == 'centos' ]] || [[ $ID == 'rhel' ]]; then
+        DISTRIBUTION=redhat
+    else
+        DISTRIBUTION="$ID"
+    fi
+
+    # We only care about the major version, so split on the dots
+    # and only take the first field (7.1 and 7 are stored as 7).
+    DISTRIBUTION_MAJOR_VERSION=$(echo "${VERSION_ID}"|cut -d . -f 1)
+else
+    # Using Python to get the distribution information is more general but it
+    # does not work on Fedora 24. That said, fallback to Python if the
+    # /etc/os-release file is not present, this will cover old OS versions like
+    # RHEL 6.
+    DISTRIBUTION=$(python -c "import platform, sys
+sys.stdout.write(platform.dist()[0])")
+    DISTRIBUTION_MAJOR_VERSION=$(python -c "import platform, sys
+sys.stdout.write(platform.dist()[1].split('.')[0])")
+fi
+
+echo "Bootstrapping jenkins for ${DISTRIBUTION} ${DISTRIBUTION_MAJOR_VERSION}"
+
+# Create the jenkins user in the jenkins group
+if  [ "${DISTRIBUTION}" == "redhat" ] && [ "${DISTRIBUTION_MAJOR_VERSION}" == "5" ]; then
+    sudo useradd --create-home --home-dir /home/jenkins jenkins
+    cat >> /etc/sudoers <<EOF
+    jenkins ALL=(ALL) NOPASSWD: ALL
+EOF
+else
+    sudo useradd --user-group --create-home --home-dir /home/jenkins jenkins
+    cat >> /etc/sudoers.d/00-jenkins<<EOF
+    jenkins ALL=(ALL) NOPASSWD: ALL
+EOF
+fi
+
+echo jenkins | sudo passwd --stdin jenkins
+
+# The SSH key gets copied in the extra data step
+# The SSH key would have been copied from /tmp/in_target.d
+PUBLIC_SSH_KEY_PATH=/tmp/in_target.d/jenkins-public-ssh-key
+
+# Authorize Jenkins to ssh into
+sudo mkdir -p /home/jenkins/.ssh
+sudo cp ${PUBLIC_SSH_KEY_PATH} /home/jenkins/.ssh/authorized_keys
+sudo chmod 700 /home/jenkins/.ssh
+sudo chmod 600 /home/jenkins/.ssh/authorized_keys
+sudo chown -R jenkins:jenkins /home/jenkins/.ssh
+
+# Create a soft link from this home directory so that jenkins can use this
+sudo ln -s /home/jenkins /var/lib/jenkins
+
+IS_FIPS=${IS_FIPS:-false}
+if [ "${IS_FIPS}" = true ];then
+    sudo yum install -y dracut-fips
+    sudo yum install -y dracut-fips-aesni
+fi

--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/package-installs.yaml
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/package-installs.yaml
@@ -1,0 +1,16 @@
+curl:
+gcc:
+git:
+libffi-devel:
+openssl-devel:
+python-devel:
+python-pip:
+java:
+redhat-lsb-core:
+redhat-rpm-config:
+vim:
+wget:
+ansible:
+attr:
+libselinux-python:
+policycoreutils-python-utils:

--- a/ci/open_stack_plugin/disk_image_builder/scripts/base_image_config.conf
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/base_image_config.conf
@@ -1,0 +1,2 @@
+rhel_7=rhel-7.4-server-x86_64-updated
+fedora_27=Fedora-Cloud-Base-27-1.6

--- a/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+init(){
+# The initializer function that installs all the dependencies and sources the environment variables.
+# The `init` function is called once only, even if builder script is run in the `all` mode or used just for calling
+# out a single image creation mode.
+
+    if [[ -f ./env_variables.sh ]];then
+        echo "sourcing environment variables for this build"
+        source ./env_variables.sh
+    fi
+
+    # Check whether Open Stack values are configured
+    if [[ (  -z "${OS_AUTH_URL}" ) || (  -z "${OS_TENANT_NAME}" ) || ( -z "${OS_USERNAME}" ) || ( -z "${OS_PASSWORD}"  ) ||  ( -z "${OS_TENANT_ID}" ) ]];then
+        echo >&2 "Image creation in openstack requires 'OS_AUTH_URL' 'OS_TENANT_NAME' and
+            'OS_USERNAME' 'OS_PASSWORD' and 'OS_TENANT_ID' set in the environment"
+        exit 1
+    fi
+
+    # Directory of the script
+    scripts_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+    # Path to the Disk Image Builder Elements
+    export ELEMENTS_PATH="${scripts_dir}/../elements"
+
+    # Installing the required dependencies
+    source "${scripts_dir}/local_dependencies.sh"
+    source "${scripts_dir}/base_image_config.conf"
+
+    # The jenkins public key must be present in the following location
+    export JENKINS_PUBLIC_SSH_KEY_PATH=~/.ssh/jenkins/id_rsa.pub
+
+    # initiallizing the output directories
+    recreate_input_output_image_dirs
+}
+
+
+conditional_init(){
+# This is used when an image is to be build separately.
+# This is used for avoiding duplicate initializations in the builder script.
+
+    if [[ -z $BASH_ARGV ]];then
+        init
+    fi
+}
+
+recreate_input_output_image_dirs(){
+# Delete and create the input and output directories.
+# Don't delete the directories if `PERSIST_IMAGES` is set in the environment.
+
+    if [[ -z "${PERSIST_IMAGES}" ]];then
+        echo "removing and creating image directories"
+        rm -rf  "${scripts_dir}/output_images";
+        rm -rf "${scripts_dir}/input_images";
+    fi
+    mkdir -p "${scripts_dir}/output_images"
+    mkdir -p "${scripts_dir}/input_images"
+}
+
+get_image_id_from_name(){
+# Retrieve Image IDs of images in OpenStack
+# param $1: Image_name
+
+    _image_id_temp="$(openstack image show -c id -f value ${1} 2> /dev/null)"
+}
+
+
+download_base_image(){
+# Download the base image from OpenStack for building our images
+# param $1: OS name
+# param $2: OS version
+# `${!temp}` evaluates the value sourced from the variable in `base_image_config.conf` file.
+
+    local temp="${1}_${2}"
+    get_image_id_from_name "${!temp}"
+    echo "downloading  ${_image_id_temp}"
+    glance image-download --progress --file  "${scripts_dir}/input_images/${1}_${2}_base.img" "${_image_id_temp}"
+}
+
+
+remove_existing_image(){
+# remove existing images in OpenStack
+# param $1: OS name
+# param $2: OS version
+# param $3: OS identifier : `fips` or `common`
+
+    echo "removing ${1}_${2}_${3}_DIB_updated"
+    value="${1}_${2}_${3}_DIB_updated"
+    get_image_id_from_name ${value}
+    if [[ ${_image_id_temp} ]];then
+        echo "deleting existing image ${_image_id_temp}"
+        glance image-delete ${_image_id_temp}
+    fi
+}
+
+
+upload_image(){
+# Upload images to OpenStack
+# param $1: OS name
+# param $2: OS version
+
+    temp="${1}_${2}"
+    remove_existing_image ${1} ${2} ${3}
+    echo "uploading ${temp}"
+    if [[ ! -f "${scripts_dir}/output_images/template-${1}${2}-os.qcow2" ]];then
+        echo >&2 "Image File ${temp} not created"
+        exit 1
+    fi
+    glance image-create --progress  --disk-format qcow2 --container-format bare --visibility private --file "${scripts_dir}/output_images/template-${1}${2}-os.qcow2" --name "${1}_${2}_${3}_DIB_updated"
+    recreate_input_output_image_dirs
+}
+
+check_rhel_params_present(){
+# Check whether `Rhel` parameters are present in the environment
+
+    if [[ ( -z "${RHN_USERNAME}" ) || ( -z "${RHN_PASSWORD}" ) || ( -z "${RHN_SKU_POOLID}" ) ]];then
+        echo >&2 "Rhel Installation must contain following parameters 'RHN_USERNAME' 'RHN_PASSWORD' and 'RHN_SKU_POOLID' set in the environment"
+        exit 1
+    fi
+}
+
+build_fedora_images(){
+# This `method` is used for building `Fedora` Images
+
+    conditional_init
+    local OS="fedora"
+    for DIB_RELEASE in 27; do
+       export DIB_RELEASE
+       download_base_image $OS $DIB_RELEASE
+       export DIB_LOCAL_IMAGE="$scripts_dir/input_images/${OS}_${DIB_RELEASE}_base.img"
+       disk-image-create -o "${scripts_dir}/output_images/template-${OS}${DIB_RELEASE}-os" fedora redhat-common vm growroot jenkins-slave
+       upload_image $OS $DIB_RELEASE 'common'
+    done
+}
+
+build_centos_images(){
+# This `method` is used for building `CentOS` Images.
+
+    conditional_init
+    local OS='centos'
+    export DIB_RELEASE=7
+    download_base_image $OS $DIB_RELEASE
+    export DIB_LOCAL_IMAGE="$scripts_dir/input_images/${OS}_${DIB_RELEASE}_base.img"
+    disk-image-create -o "${scripts_dir}/output_images/template-${OS}${DIB_RELEASE}-os" centos7 grub2 bootloader selinux-permissive jenkins-slave vm simple-init growroot epel
+    upload_image $OS $DIB_RELEASE 'common'
+}
+
+
+build_rhelos_images(){
+# This `method` is used for building `Rhel` Images.
+
+    conditional_init
+    check_rhel_params_present
+    local OS='rhel'
+    export DIB_RELEASE=7
+    download_base_image $OS $DIB_RELEASE
+    export DIB_LOCAL_IMAGE="$scripts_dir/input_images/${OS}_${DIB_RELEASE}_base.img"
+    export REG_USER=$RHN_USERNAME
+    export REG_PASSWORD=$RHN_PASSWORD
+    export REG_POOL_ID=$RHN_SKU_POOLID
+    export REG_METHOD=portal
+    disk-image-create -o "${scripts_dir}/output_images/template-${OS}${DIB_RELEASE}-os" rhel7 rhel-common simple-init vm growroot jenkins-slave epel
+    upload_image $OS $DIB_RELEASE 'common'
+}
+
+
+build_rhel_fips_images(){
+# This `method` is used for building `Rhel` Images with FIPS enabled.
+
+    conditional_init
+    check_rhel_params_present
+    local OS='rhel'
+    export DIB_RELEASE=7
+    download_base_image $OS $DIB_RELEASE
+    export DIB_LOCAL_IMAGE="$scripts_dir/input_images/${OS}_${DIB_RELEASE}_base.img"
+    export DIB_BOOTLOADER_DEFAULT_CMDLINE="fips=1"
+    export REG_USER=$RHN_USERNAME
+    export REG_PASSWORD=$RHN_PASSWORD
+    export REG_POOL_ID=$RHN_SKU_POOLID
+    export REG_METHOD=portal
+    export IS_FIPS=true # This flag will set the necessary boot cmd line parameters in the install.d and finalise.d steps
+    disk-image-create -o "${scripts_dir}/output_images/template-${OS}${DIB_RELEASE}-os" rhel7 rhel-common simple-init vm growroot jenkins-slave bootloader epel
+    upload_image $OS $DIB_RELEASE 'fips'
+}
+
+if [[ ( ! -z "${1}" ) && ( $1 = "all" ) ]];then
+    init
+    build_fedora_images
+    build_rhelos_images
+    build_rhel_fips_images
+fi
+

--- a/ci/open_stack_plugin/disk_image_builder/scripts/local_dependencies.sh
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/local_dependencies.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+sudo yum -y install qemu-img yum-utils
+
+# installing openstack dependencies
+pip install python-novaclient
+pip install python-cinderclient
+pip install python-glanceclient
+pip install python-keystoneclient
+pip install python-neutronclient
+pip install python-swiftclient
+pip install python-openstackclient
+
+# installing the disk_image_builder
+pip install diskimage-builder
+


### PR DESCRIPTION
This jobs will be creating new images on the fly in the openstack using
the glance Apis. These jobs will be triggered in the Image building
machine and is used for replacing existing images with new ones.