### PR TITLE
Make variable expansions safer

### DIFF
--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/extra-data.d/20-jenkins-public-ssh-key
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/extra-data.d/20-jenkins-public-ssh-key
@@ -1,13 +1,13 @@
 #!/bin/bash
 # This script runs on the host machine in which the disk image builder is running 
-if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
     set -x
 fi
 set -euo pipefail
 
-echo "JENKINS ssh key path $JENKINS_PUBLIC_SSH_KEY_PATH"
+echo "JENKINS ssh key path ${JENKINS_PUBLIC_SSH_KEY_PATH}"
 echo "JENKINS ssh key real path "
-echo "$(realpath $JENKINS_PUBLIC_SSH_KEY_PATH)"
+echo "$(realpath ${JENKINS_PUBLIC_SSH_KEY_PATH})"
 JENKINS_PUBLIC_SSH_KEY_PATH="${JENKINS_PUBLIC_SSH_KEY_PATH:-/home/jenkins/.ssh/id_rsa.pub}"
 
 if [ ! -f "${JENKINS_PUBLIC_SSH_KEY_PATH}" ]; then

--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/finalise.d/58-setboot
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/finalise.d/58-setboot
@@ -3,12 +3,12 @@
 # This script will get the UUID of the boot filesystem and append that information with the fips flag to the
 # bootloader commandline for FIPS to be enabled.
 
-IS_FIPS=${IS_FIPS:-false}
+IS_FIPS="${IS_FIPS:-false}"
 if [ "${IS_FIPS}" = true ];then
     echo "Setting up Fips environment"
     dracut --force
-    boot_dev=$(df /boot --output=source |tail -n+2)
-	uuid_dev=$(blkid $boot_dev -o export |grep -i UUID)
-	grubby --update-kernel=DEFAULT --args="boot=${uuid_dev}"
+    boot_dev="$(df /boot --output=source | tail -n+2)"
+    uuid_dev="$(blkid "${boot_dev}" -o export | grep -i UUID)"
+    grubby --update-kernel=DEFAULT --args="boot=${uuid_dev}"
 fi
 

--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/install.d/21-bootstrap
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/install.d/21-bootstrap
@@ -15,24 +15,24 @@ if [ -f /etc/os-release ]; then
     # set DISTRIBUTION based on ID: If it's rhel or centos,
     # make it the common "redhat". Otherwise, use ID directly.
     # For our purposes, this means it should either be "redhat" or "fedora".
-    if [[ $ID == 'centos' ]] || [[ $ID == 'rhel' ]]; then
+    if [[ "${ID}" == 'centos' ]] || [[ "${ID}" == 'rhel' ]]; then
         DISTRIBUTION=redhat
     else
-        DISTRIBUTION="$ID"
+        DISTRIBUTION="${ID}"
     fi
 
     # We only care about the major version, so split on the dots
     # and only take the first field (7.1 and 7 are stored as 7).
-    DISTRIBUTION_MAJOR_VERSION=$(echo "${VERSION_ID}"|cut -d . -f 1)
+    DISTRIBUTION_MAJOR_VERSION="$(echo "${VERSION_ID}" | cut -d . -f 1)"
 else
     # Using Python to get the distribution information is more general but it
     # does not work on Fedora 24. That said, fallback to Python if the
     # /etc/os-release file is not present, this will cover old OS versions like
     # RHEL 6.
-    DISTRIBUTION=$(python -c "import platform, sys
-sys.stdout.write(platform.dist()[0])")
-    DISTRIBUTION_MAJOR_VERSION=$(python -c "import platform, sys
-sys.stdout.write(platform.dist()[1].split('.')[0])")
+    DISTRIBUTION="$(python -c "import platform, sys
+sys.stdout.write(platform.dist()[0])")"
+    DISTRIBUTION_MAJOR_VERSION="$(python -c "import platform, sys
+sys.stdout.write(platform.dist()[1].split('.')[0])")"
 fi
 
 echo "Bootstrapping jenkins for ${DISTRIBUTION} ${DISTRIBUTION_MAJOR_VERSION}"
@@ -58,7 +58,7 @@ PUBLIC_SSH_KEY_PATH=/tmp/in_target.d/jenkins-public-ssh-key
 
 # Authorize Jenkins to ssh into
 sudo mkdir -p /home/jenkins/.ssh
-sudo cp ${PUBLIC_SSH_KEY_PATH} /home/jenkins/.ssh/authorized_keys
+sudo cp "${PUBLIC_SSH_KEY_PATH}" /home/jenkins/.ssh/authorized_keys
 sudo chmod 700 /home/jenkins/.ssh
 sudo chmod 600 /home/jenkins/.ssh/authorized_keys
 sudo chown -R jenkins:jenkins /home/jenkins/.ssh
@@ -66,13 +66,13 @@ sudo chown -R jenkins:jenkins /home/jenkins/.ssh
 # Create a soft link from this home directory so that jenkins can use this
 sudo ln -s /home/jenkins /var/lib/jenkins
 
-IS_FIPS=${IS_FIPS:-false}
+IS_FIPS="${IS_FIPS:-false}"
 if [ "${IS_FIPS}" = true ];then
     sudo yum install -y dracut-fips
     sudo yum install -y dracut-fips-aesni
 fi
 
-DOCKER=${DOCKER:-false}
+DOCKER="${DOCKER:-false}"
 if [ "${DOCKER}" = true ]; then
     echo "installing docker"
     sudo yum install -y docker

--- a/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
@@ -45,7 +45,7 @@ conditional_init(){
 # This is used when an image is to be build separately.
 # This is used for avoiding duplicate initializations in the builder script.
 
-    if [[ -z "$BASH_ARGV" ]];then
+    if [[ -z "${BASH_ARGV}" ]];then
         init
     fi
 }
@@ -93,7 +93,7 @@ remove_existing_image(){
     echo "removing ${1}_${2}_${3}_DIB_updated"
     value="${1}_${2}_${3}_DIB_updated"
     get_image_id_from_name "${value}"
-    if [[ ${_image_id_temp} ]];then
+    if [[ "${_image_id_temp}" ]];then
         echo "deleting existing image ${_image_id_temp}"
         glance image-delete "${_image_id_temp}"
     fi
@@ -106,7 +106,7 @@ upload_image(){
 # param $2: OS version
 
     temp="${1}_${2}"
-    remove_existing_image ${1} ${2} ${3}
+    remove_existing_image "${1}" "${2}" "${3}"
     echo "uploading ${temp}"
     if [[ ! -f "${scripts_dir}/output_images/template-${1}${2}-os.qcow2" ]];then
         echo >&2 "Image File ${temp} not created"
@@ -130,13 +130,13 @@ build_fedora_images(){
 
     conditional_init
     local OS="fedora"
-    FEDORA_RELEASES="${FEDORA_RELEASES:-$fedora_default}"
+    FEDORA_RELEASES="${FEDORA_RELEASES:-${fedora_default}}"
     for DIB_RELEASE in "${FEDORA_RELEASES}"; do
        export DIB_RELEASE
-       download_base_image "$OS" "$DIB_RELEASE"
-       export DIB_LOCAL_IMAGE="$scripts_dir/input_images/${OS}_${DIB_RELEASE}_base.img"
+       download_base_image "${OS}" "${DIB_RELEASE}"
+       export DIB_LOCAL_IMAGE="${scripts_dir}/input_images/${OS}_${DIB_RELEASE}_base.img"
        disk-image-create -o "${scripts_dir}/output_images/template-${OS}${DIB_RELEASE}-os" fedora redhat-common vm growroot jenkins-slave
-       upload_image "$OS" "$DIB_RELEASE" "$identifier"
+       upload_image "${OS}" "${DIB_RELEASE}" "${identifier}"
        unset DOCKER # unsetting docker
     done
 }
@@ -146,13 +146,13 @@ build_centos_images(){
 
     conditional_init
     local OS='centos'
-    CENTOS_RELEASES="${CENTOS_RELEASES:-$centos_default}"
+    CENTOS_RELEASES="${CENTOS_RELEASES:-${centos_default}}"
     for DIB_RELEASE in "${CENTOS_RELEASES}"; do
         export DIB_RELEASE
-        download_base_image $OS $DIB_RELEASE
-        export DIB_LOCAL_IMAGE="$scripts_dir/input_images/${OS}_${DIB_RELEASE}_base.img"
+        download_base_image "${OS}" "${DIB_RELEASE}"
+        export DIB_LOCAL_IMAGE="${scripts_dir}/input_images/${OS}_${DIB_RELEASE}_base.img"
         disk-image-create -o "${scripts_dir}/output_images/template-${OS}${DIB_RELEASE}-os" centos7 grub2 bootloader selinux-permissive jenkins-slave vm simple-init growroot epel
-        upload_image "$OS" "$DIB_RELEASE" "$identifier"
+        upload_image "${OS}" "${DIB_RELEASE}" "${identifier}"
     done
 }
 
@@ -163,17 +163,17 @@ build_rhelos_images(){
     conditional_init
     check_rhel_params_present
     local OS='rhel'
-    RHEL_RELEASES="${RHEL_RELEASES:-$rhel_default}"
+    RHEL_RELEASES="${RHEL_RELEASES:-${rhel_default}}"
     for DIB_RELEASE in "${RHEL_RELEASES}"; do
         export DIB_RELEASE
-        download_base_image "$OS" "$DIB_RELEASE"
-        export DIB_LOCAL_IMAGE="$scripts_dir/input_images/${OS}_${DIB_RELEASE}_base.img"
-        export REG_USER="$RHN_USERNAME"
-        export REG_PASSWORD="$RHN_PASSWORD"
-        export REG_POOL_ID="$RHN_SKU_POOLID"
+        download_base_image "${OS}" "${DIB_RELEASE}"
+        export DIB_LOCAL_IMAGE="${scripts_dir}/input_images/${OS}_${DIB_RELEASE}_base.img"
+        export REG_USER="${RHN_USERNAME}"
+        export REG_PASSWORD="${RHN_PASSWORD}"
+        export REG_POOL_ID="${RHN_SKU_POOLID}"
         export REG_METHOD=portal
         disk-image-create -o "${scripts_dir}/output_images/template-${OS}${DIB_RELEASE}-os" rhel7 rhel-common simple-init vm growroot jenkins-slave epel
-        upload_image "$OS" "$DIB_RELEASE" "$identifier"
+        upload_image "${OS}" "${DIB_RELEASE}" "${identifier}"
     done
 }
 
@@ -184,23 +184,23 @@ build_rhel_fips_images(){
     conditional_init
     check_rhel_params_present
     local OS='rhel'
-    RHEL_RELEASES="${RHEL_RELEASES:-$rhel_default}"
+    RHEL_RELEASES="${RHEL_RELEASES:-${rhel_default}}"
     for DIB_RELEASE in "${RHEL_RELEASES}"; do
         export DIB_RELEASE
-        download_base_image "$OS" "$DIB_RELEASE"
-        export DIB_LOCAL_IMAGE="$scripts_dir/input_images/${OS}_${DIB_RELEASE}_base.img"
+        download_base_image "${OS}" "${DIB_RELEASE}"
+        export DIB_LOCAL_IMAGE="${scripts_dir}/input_images/${OS}_${DIB_RELEASE}_base.img"
         export DIB_BOOTLOADER_DEFAULT_CMDLINE="fips=1"
-        export REG_USER="$RHN_USERNAME"
-        export REG_PASSWORD="$RHN_PASSWORD"
-        export REG_POOL_ID="$RHN_SKU_POOLID"
+        export REG_USER="${RHN_USERNAME}"
+        export REG_PASSWORD="${RHN_PASSWORD}"
+        export REG_POOL_ID="${RHN_SKU_POOLID}"
         export REG_METHOD=portal
         export IS_FIPS=true # This flag will set the necessary boot cmd line parameters in the install.d and finalise.d steps
         disk-image-create -o "${scripts_dir}/output_images/template-${OS}${DIB_RELEASE}-os" rhel7 rhel-common simple-init vm growroot jenkins-slave bootloader epel
-        upload_image "$OS" "$DIB_RELEASE" 'fips'
+        upload_image "${OS}" "${DIB_RELEASE}" 'fips'
     done
 }
 
-if [[ ( ! -z "${1}" ) && ( "$1" = "all" ) ]];then
+if [[ ( ! -z "${1}" ) && ( "${1}" = "all" ) ]];then
     init
     build_fedora_images
     build_rhelos_images


### PR DESCRIPTION
Do the following in several newly-added Bash scripts:

* Surround all variable expansions with double quotes.
* Use curly-brace syntax for variables.

What does this look like in practice? Code like `my/$variable/path` is
changed to `"my/${variable}/path"`.

Together, these two changes make variable expansions much safer. Using
quotes ensures that Bash won't do things like split expanded variables
based on whitespace they contain. And using curly-brace variable syntax
avoids ambiguity surrounding which characters might or might not be
included in a variable name.