### PR TITLE
Correcting jenkins jobs to delete slave nodes in open stack

### DIFF
--- a/ci/jjb/jobs/pr-docs.yaml
+++ b/ci/jjb/jobs/pr-docs.yaml
@@ -84,7 +84,7 @@
             exit $docs_exit_code
 
     publishers:
-      - mark-node-offline
+      - delete-slave-node
 
 - job-group:
     name: 'docs-plugins-pr-jobs'

--- a/ci/jjb/jobs/unittests.yaml
+++ b/ci/jjb/jobs/unittests.yaml
@@ -170,7 +170,7 @@
           results: 'test/*.xml'
           keep-long-stdio: true
           test-stability: true
-      - mark-node-offline
+      - delete-slave-node
 
 - job-template:
     name: 'unittest-{pulp_plugin}-pr'
@@ -325,7 +325,7 @@
           keep-long-stdio: true
           test-stability: true
       - email-notify-owners
-      - mark-node-offline
+      - delete-slave-node
 
 - job-group:
     name: 'unittest-plugins-pr-jobs'


### PR DESCRIPTION
This commit take care of deleting the slave nodes that are created by
running jenkins jobs. This is accomplished with the help of the macro
`delete-slave-node`, which is a groovy script for slave removal