### PR TITLE
Simplify discovery of /boot UUID

### DIFF
--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/finalise.d/58-setboot
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/finalise.d/58-setboot
@@ -7,8 +7,6 @@ IS_FIPS="${IS_FIPS:-false}"
 if [ "${IS_FIPS}" = true ];then
     echo "Setting up Fips environment"
     dracut --force
-    boot_dev="$(df /boot --output=source | tail -n+2)"
-    uuid_dev="$(blkid "${boot_dev}" -o export | grep -i UUID)"
-    grubby --update-kernel=DEFAULT --args="boot=${uuid_dev}"
+    grubby --update-kernel=DEFAULT --args="boot=UUID=$(findmnt /boot -o UUID)"
 fi
 


### PR DESCRIPTION
Discovering the UUID of the `/boot` device is simple:

    findmnt /boot -o UUID

There's no reason to use other tools and use grep, sed, awk, tail, etc
to parse their output.