### PR TITLE
Add mock as dependency for fixtures.

### DIFF
--- a/ci/jjb/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jjb/jobs/pulp-fixtures-publisher.yaml
@@ -25,6 +25,7 @@
               gpg \
               jq \
               make \
+              mock \
               patch \
               puppet \
               python3-jinja2-cli \


### PR DESCRIPTION
In order to execute scripts related to rich dependency content, the mock
executable must be available.