### PR TITLE
Elevating user privileges for installing with mock dependency

### DIFF
--- a/ci/jjb/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jjb/jobs/pulp-fixtures-publisher.yaml
@@ -31,7 +31,7 @@
               python3-jinja2-cli \
               rpm-build \
               rpm-sign
-            make fixtures base_url=https://repos.fedorapeople.org/pulp/pulp/
+            sudo make fixtures base_url=https://repos.fedorapeople.org/pulp/pulp/
             rsync -arvze "ssh -o StrictHostKeyChecking=no" --delete \
                 fixtures/* \
                 pulpadmin@repos.fedorapeople.org:/srv/repos/pulp/pulp/fixtures


### PR DESCRIPTION
The pulp fixtures publisher job was breaking as the mock dependency was
failing to run as a non-root user. Fixing this issue by elevating to
root privilege.

Refer https://fedoraproject.org/wiki/Using_Mock_to_test_package_builds