### PR TITLE
Adding logic for removing old builds from jenkins

### DIFF
--- a/ci/jjb/jobs/macros.yaml
+++ b/ci/jjb/jobs/macros.yaml
@@ -124,6 +124,13 @@
                 - koliveir
                 - ragbalak
 
+# Discard old builds that are month old for the job
+- property:
+    name: discard-old-builds
+    properties:
+    - build-discarder:
+        num-to-keep: 100
+
 # Used in the "ci-workflow-runtest" defaults definition.
 - publisher:
     name: default-ci-workflow-publishers

--- a/ci/jjb/jobs/pulp-dev.yaml
+++ b/ci/jjb/jobs/pulp-dev.yaml
@@ -3,6 +3,7 @@
     node: '{os}-os'
     properties:
         - qe-ownership
+        - discard-old-builds
     scm:
         - pulp-ci-github
     wrappers:

--- a/ci/jjb/jobs/pulp-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp-smash-runner.yaml
@@ -56,6 +56,7 @@
                 where the CA certificate was installed.
     properties:
         - qe-ownership
+        - discard-old-builds
     scm:
         - pulp-ci-github
     wrappers:


### PR DESCRIPTION
The current Jenkins Jobs like Pulp Smash runner takes ample time for
page loads in UI. This is because of excess number of builds that are
accumulated when page is loading. This commit will remove all the builds
aged more than a month on the next run.