### PR TITLE
Adding logic for adding Rhel 7.6 images in openstack

### DIFF
--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/pre-install.d/20-vault-repo
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/pre-install.d/20-vault-repo
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set_vault_repo_rhel_7_6(){
+echo "adding vault repo to RHEL 7.6"
+cat >/etc/yum.repos.d/vault.repo <<EOL
+[vault_repo]
+name=Vault Repository
+baseurl=http://download.devel.redhat.com/composes/nightly/latest-RHEL-7.6/compose/Server/x86_64/os/
+enabled=1
+gpgcheck=0
+EOL
+
+}
+
+RHEL_VER="${RHEL_VER:-7}"
+if [ "${RHEL_VER}" = "7_6" ];then
+    set_vault_repo_rhel_7_6
+    yum -y update
+fi

--- a/ci/open_stack_plugin/disk_image_builder/scripts/base_image_config.conf
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/base_image_config.conf
@@ -1,9 +1,10 @@
-rhel_default=7
+rhel_default=7,7_6
 fedora_default=27,28
 centos_default=7
 
 rhel_7=rhel-7.4-server-x86_64-updated
 rhel_6=rhel-6.8-server-x86_64-updated
+rhel_7_6=rhel-7.6-server-x86_64-latest
 
 fedora_27=Fedora-Cloud-Base-27-1.6
 fedora_28=Fedora-Cloud-Base-28-compose-latest

--- a/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
@@ -167,6 +167,7 @@ build_rhelos_images(){
     IFS=',' read -ra RELEASES <<< "${RHEL_RELEASES}"
     for RELEASE in "${RELEASES[@]}"; do
         download_base_image "${OS}" "${RELEASE}"
+        export RHEL_VER="${RELEASE}"
         export DIB_LOCAL_IMAGE="${scripts_dir}/input_images/${OS}_${RELEASE}_base.img"
         export REG_USER="${RHN_USERNAME}"
         export REG_PASSWORD="${RHN_PASSWORD}"


### PR DESCRIPTION
This commit will add disk image builder components for building 7.6 rhel
images into openstack. This pulls the base rhel 7.6 image, customize it
, adds a rhel-7.6 vault repo into the created image and then completes
the build job