### PR TITLE
Adding debuggers for master-dev jobs in CI

### DIFF
--- a/ci/jjb/jobs/macros.yaml
+++ b/ci/jjb/jobs/macros.yaml
@@ -52,6 +52,9 @@
     # This hostname can be connected from other open stack vms.
     builders:
         - shell: |
+            # Hostnames that are set
+            echo "$(hostname --all-fqdn)"
+            echo "$(hostname)"
             # Setting the hostname of the system to enable connectivity
             hostname="$(hostname --all-fqdn | grep openstacklocal | head -n 1)"
             hostname="$(echo ${hostname})"


### PR DESCRIPTION
The nightlies are failing to run because of dns resolution. Will help if
the actual hostnames of the slaves are known during such failures. This
PR will help in logging the `hostname` and `hostname --all-fqdn` on the
slave system.