### PR TITLE
Drop an unnecessary subshell

### DIFF
--- a/ci/jjb/jobs/macros.yaml
+++ b/ci/jjb/jobs/macros.yaml
@@ -52,9 +52,9 @@
     # This hostname can be connected from other open stack vms.
     builders:
         - shell: |
-            # Hostnames that are set
-            echo "$(hostname --all-fqdn)"
-            echo "$(hostname)"
+            # This information can aid in debugging failed jobs.
+            hostname --all-fqdn
+            hostname
             # Setting the hostname of the system to enable connectivity
             hostname="$(hostname --all-fqdn | grep openstacklocal | head -n 1)"
             hostname="$(echo ${hostname})"


### PR DESCRIPTION
The `hostname` executable prints to stdout. There's no benefit to
running the executable in a subshell, capturing that subshell's stdout,
and then printing the captured stdout with `echo`.

See: 9ed8eab94f6ac999ede8c3e481c94cc8a0315962