### PR TITLE
Adding F28 python3 firewalld bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 install:
-  - pip install ansible 'jenkins-job-builder<2'
+  - pip install ansible 'jenkins-job-builder==2.0.2'
 script:
   - ansible-playbook --syntax-check ci/ansible/*.yaml
   - cd ci/jjb && jenkins-jobs --conf jenkins_jobs.ini test -r -o "$(mktemp --directory)" jobs

--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -50,7 +50,7 @@
     package:
       name:
         - firewalld
-        - python-firewall
+        - "python{{ ansible_python.version.major }}-firewall"
       state: present
 
   - name: Start and enable firewalld

--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -41,8 +41,9 @@
     - 2.16:
         pulp_version: '2.16'
     os:
-    - 'f27'
-    - 'rhel7'
+    - f27
+    - rhel7
+    script-var: ''
     reverse_trigger: '{build_version}-dev'
     jobs:
     - pulp-{build_version}-dev-{os}
@@ -57,13 +58,16 @@
         pulp_version: '2.18'
         reverse_trigger: '2-master'
     os:
-    - 'f27'
-    - 'f28'
-    - 'rhel7'
-    - 'rhel7-fips'
+    - f27
+    - f28:
+        script-var: '-f28'
+    - rhel7
+    - rhel7-fips
     reverse_trigger: '{build_version}-dev'
+    script-var: ''
     jobs:
     - pulp-{build_version}-dev-{os}
+
 
 - project:
     name: disk-image-builder-base

--- a/ci/jjb/jobs/pulp-dev.yaml
+++ b/ci/jjb/jobs/pulp-dev.yaml
@@ -26,8 +26,10 @@
             !include-raw-escape:
                 - 'ssh-setup.sh'
         - shell:
+            !include-raw:
+                - 'pulp-install{script-var}.sh'
+        - shell:
             !include-raw-escape:
-                - 'pulp-install.sh'
                 - 'pulp-coverage-setup.sh'
                 - 'pulp-smash-parameters.sh'
         - inject:

--- a/ci/jjb/scripts/pulp-install-f28.sh
+++ b/ci/jjb/scripts/pulp-install-f28.sh
@@ -1,0 +1,12 @@
+setenforce permissive
+sudo yum -y install ansible attr git libselinux-python
+echo 'localhost' > hosts
+source "${RHN_CREDENTIALS}"
+export ANSIBLE_CONFIG="${PWD}/ci/ansible/ansible.cfg"
+ansible-playbook --connection local -i hosts ci/ansible/pulp_server.yaml \
+    -e "pulp_build=${PULP_BUILD}" \
+    -e "pulp_version=${PULP_VERSION}" \
+    -e "rhn_password=${RHN_PASSWORD}" \
+    -e "rhn_pool=${RHN_POOL}" \
+    -e "rhn_username=${RHN_USERNAME}" \
+    -e "ansible_python_interpreter=/usr/bin/python3"


### PR DESCRIPTION
This PR addresses two issues that are related to Fedora28.
* It makes sure Python3 interpreter is used for running Ansible in Fedora 28. This was required since the `python2-firewall` packages are not used in F28.
* SELinux is set in the **permissive** mode in F28, Since the tasks that starts squid.service [1] fails in F28.

[1] https://pulp.plan.io/issues/3926