### PR TITLE
Install Python 2 on Fedora

### DIFF
--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -1,4 +1,11 @@
 ---
+# Pulp 2 requires Python 2.
+- name: Install Python 2 (Fedora)
+  package:
+    name: python
+    state: present
+  when: ansible_distribution == "Fedora"
+
 - block:
 
   - name: Open firewall ports (iptables)


### PR DESCRIPTION
Pulp 2 requires Python 2.