### PR TITLE
Elevating root privilege of `setenforce` in f28 jobs

### DIFF
--- a/ci/jjb/scripts/pulp-install-f28.sh
+++ b/ci/jjb/scripts/pulp-install-f28.sh
@@ -1,4 +1,5 @@
-setenforce permissive
+# Setting SELinux in permissive as squid start fails in SELinux enabled F28
+sudo setenforce permissive
 sudo yum -y install ansible attr git libselinux-python
 echo 'localhost' > hosts
 source "${RHN_CREDENTIALS}"


### PR DESCRIPTION
The f28 jobs failed as setenforce was run as a normal user. Escalating
privileges for ensuring this works.