### PR TITLE
Changing the base conf to point to rhel 7.5

### DIFF
--- a/ci/nodepool/scripts/fix_hostname.sh
+++ b/ci/nodepool/scripts/fix_hostname.sh
@@ -13,3 +13,7 @@ if [ -n "${hostname:-}" ]; then
         sudo tee /etc/hostname <<< "${hostname}"
     fi
 fi
+
+# Adding the OS information for debugging purposes
+echo "OS versions"
+cat /etc/os-release

--- a/ci/open_stack_plugin/disk_image_builder/scripts/base_image_config.conf
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/base_image_config.conf
@@ -2,7 +2,7 @@ rhel_default=7
 fedora_default=27,28
 centos_default=7
 
-rhel_7=rhel-7.4-server-x86_64-updated
+rhel_7=rhel-7.5-server-x86_64-updated
 rhel_6=rhel-6.8-server-x86_64-updated
 
 fedora_27=Fedora-Cloud-Base-27-1.6


### PR DESCRIPTION
Though the image label `rhel-7.4-server-x86_64-updated` was uploading
images - rhel7.5, The term was misleading and hence changing it to point
to `rhel-7.5-server-x86_64-updated`. Also adding OS version in the
output in jjbs.
`