### PR TITLE
Simplify script to install pulp F28.

### DIFF
--- a/ci/jjb/scripts/pulp-install-f28.sh
+++ b/ci/jjb/scripts/pulp-install-f28.sh
@@ -1,13 +1,8 @@
-# Setting SELinux in permissive as squid start fails in SELinux enabled F28
-sudo setenforce permissive
-sudo yum -y install ansible attr git libselinux-python
+sudo dnf -y update
+sudo dnf -y install ansible attr git libselinux-python
 echo 'localhost' > hosts
-source "${RHN_CREDENTIALS}"
 export ANSIBLE_CONFIG="${PWD}/ci/ansible/ansible.cfg"
 ansible-playbook --connection local -i hosts ci/ansible/pulp_server.yaml \
     -e "pulp_build=${PULP_BUILD}" \
     -e "pulp_version=${PULP_VERSION}" \
-    -e "rhn_password=${RHN_PASSWORD}" \
-    -e "rhn_pool=${RHN_POOL}" \
-    -e "rhn_username=${RHN_USERNAME}" \
     -e "ansible_python_interpreter=/usr/bin/python3"


### PR DESCRIPTION
Remove SELinux permissive.
See: https://bodhi.fedoraproject.org/updates/FEDORA-2018-902974a33b

Remove variables related to RHEL. And uses `dnf` instead of `yum` as
package manager.