### PR TITLE
Add Pulp 2.17 to the upgrade job.

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -88,13 +88,13 @@
 - project:
     name: pulp-upgrade
     os:
-        - f27
+        - f28
         - rhel7
     pulp_version:
         - 2.15-stable
         - 2.16-stable
     upgrade_pulp_version:
-        - 2.16-beta
+        - 2.17-beta
     jobs:
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'
 


### PR DESCRIPTION
Add Pulp 2.17 beta to the upgrade job.

Moreover, replace F28 instead of F27 as targeted OS.