### PR TITLE
Updating image name back to rhel7_4 updated

### DIFF
--- a/ci/open_stack_plugin/disk_image_builder/scripts/base_image_config.conf
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/base_image_config.conf
@@ -2,7 +2,7 @@ rhel_default=7
 fedora_default=27,28
 centos_default=7
 
-rhel_7=rhel-7.5-server-x86_64-updated
+rhel_7=rhel-7.4-server-x86_64-updated
 rhel_6=rhel-6.8-server-x86_64-updated
 
 fedora_27=Fedora-Cloud-Base-27-1.6


### PR DESCRIPTION
Fips jobs are failing, since the image with rhel 7.5 are not getting
built properly. Migrating back to `rhel7.4` in the config file. Though
the base image points to 7.4, the image being built is 7.5.