### PR TITLE
Update version of default installation to 2.17

### DIFF
--- a/ci/ansible/roles/pulp/defaults/main.yaml
+++ b/ci/ansible/roles/pulp/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 
 # Pulp version to install
-pulp_version: 2.16
+pulp_version: 2.17
 
 # Pulp build to install, the choices are: beta, nightly and stable
 pulp_build: nightly


### PR DESCRIPTION
Pulp 2.17 GA was relased. See: https://repos.fedorapeople.org/repos/pulp/pulp/stable/2.17/

Update default installation to use this new version.