### PR TITLE
Update node used to run smash

### DIFF
--- a/ci/jjb/jobs/pulp-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp-smash-runner.yaml
@@ -4,7 +4,7 @@
     properties:
         - copyartifact:
             projects: pulp-*-dev-*
-    node: f27-os
+    node: f28-os
     parameters:
         - string:
             name: PULP_SMASH_SYSTEM_HOSTNAME


### PR DESCRIPTION
Update the node used to run pulp-smash from Fedora 27 to Fedora 28.