### PR TITLE
Add yaml callback to ansible.cfg

### DIFF
--- a/ci/ansible/ansible.cfg
+++ b/ci/ansible/ansible.cfg
@@ -1,3 +1,6 @@
 # See: https://docs.ansible.com/ansible/intro_configuration.html
 [privilege_escalation]
 become = True
+# See: https://docs.ansible.com/ansible/latest/plugins/callback.html#callback-plugins
+[defaults]
+stdout_callback = yaml


### PR DESCRIPTION
yaml callback to improve stdout format. It does make error messages more user
friendly.

See: https://docs.ansible.com/ansible/latest/plugins/callback/yaml.html

This requires Ansible2.5 or newer.