### PR TITLE
Migrating ``disk-image-builder-base`` job to Open Stack node.

### DIFF
--- a/ci/jjb/jobs/disk-image-builder.yaml
+++ b/ci/jjb/jobs/disk-image-builder.yaml
@@ -1,6 +1,6 @@
 - job-template:
     name: 'disk-image-builder-base'
-    node: 'disk-image-builder'
+    node: 'disk-image-builder-os'
     properties:
         - qe-ownership
     scm:
@@ -20,3 +20,6 @@
             !include-raw-escape:
                 - 'disk-image-builder.sh'
 
+    publishers:
+        - email-notify-owners
+        - delete-slave-node

--- a/ci/jjb/scripts/disk-image-builder.sh
+++ b/ci/jjb/scripts/disk-image-builder.sh
@@ -3,6 +3,7 @@ chmod +x ./env_variables.sh
 cat "${RHN_CREDENTIALS}" >> ./env_variables.sh
 cat "${Open_Stack_Credentials}" >> ./env_variables.sh
 rm -rf ~/.venvs/openstack/
+# Creating a python virtual env, since pypi packages are needed
 virtualenv ~/.venvs/openstack/
 source ~/.venvs/openstack/bin/activate
 ./ci/open_stack_plugin/disk_image_builder/scripts/builder.sh all

--- a/ci/open_stack_plugin/disk_image_builder/README.md
+++ b/ci/open_stack_plugin/disk_image_builder/README.md
@@ -309,3 +309,27 @@ echo "rhel_6=rhel_6_image_name" >> base_image_config.conf
 ```
 
 These commands can also be present in a file `env_variables.sh` in the `$PWD` where the script is run from.
+
+### Provisioning new images/distros
+
+New Images/distros can be added in OpenStack and used in jenkins by using the following steps.
+
+1) Edit the ``scripts/disk_image_builder.conf`` file as follows.
+
+   example: If a new image is available in OpenStack for Fedora 29, add the line
+   ``fedora_29=<image_name_in_open_stack>`` in the file.And also append the value
+   ``29`` to fedora_default seperated by ``,``. Thus if the value of fedora_default
+   was ``27,28`` , it should be changed to ``27,28,29``.
+
+2) This configuration change will add a new image in the openstack under the name
+   ``fedora_29_common_DIB_updated``.
+
+3) Once an image is available, Jenkins has to be configured so that a new instance
+   of this image can be provisioned.
+
+4) For jenkins configuration, go to Jenkins > Manage Jenkins > Configure System
+   \> Cloud (Openstack) > Add the cloud information(These data can be obtained
+   from OpenStack) > Ensure the name of the image is the ``fedora_29_common_DIB_updated``.
+
+5) Set an appropriate label. All the jenkins jobs that has to run on this image instance
+   should use this label.

--- a/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/install.d/21-bootstrap
+++ b/ci/open_stack_plugin/disk_image_builder/elements/jenkins-slave/install.d/21-bootstrap
@@ -84,3 +84,6 @@ if [ "${DOCKER}" = true ]; then
     # add -G docker to docker's OPTIONS in /etc/sysconfig/docker
     sudo sed -i "s/^\(OPTIONS=.*\)'/\1 -G docker'/" /etc/sysconfig/docker
 fi
+
+# Installing virtualenv within the creating image
+sudo pip install virtualenv

--- a/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
@@ -28,7 +28,9 @@ init(){
     source "${scripts_dir}/base_image_config.conf"
 
     # The jenkins public key must be present in the following location
-    export JENKINS_PUBLIC_SSH_KEY_PATH=~/.ssh/jenkins/id_rsa.pub
+    # These keys will be copied to the image being built, which allows ssh
+    # access to those image instances.
+    export JENKINS_PUBLIC_SSH_KEY_PATH=~/.ssh/authorized_keys
 
     # Identifier for the images
     identifier=common

--- a/ci/open_stack_plugin/disk_image_builder/scripts/local_dependencies.sh
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/local_dependencies.sh
@@ -2,7 +2,9 @@
 
 sudo yum -y install qemu-img yum-utils
 
-# installing openstack dependencies
+# Installing openstack dependencies
+# These dependencies are required for building an
+# image in openstack.
 pip install python-novaclient
 pip install python-cinderclient
 pip install python-glanceclient
@@ -11,6 +13,6 @@ pip install python-neutronclient
 pip install python-swiftclient
 pip install python-openstackclient
 
-# installing the disk_image_builder
+# Installing the disk_image_builder
 pip install diskimage-builder
 


### PR DESCRIPTION
The current ``disk-image-builder-base`` job is running on a physical
instance. Migrating this job to be run on open stack gives much more
availability. As a part of this commit, a new instance called
``disk-image-builder-os`` is set up in the jenkins-openstack cloud
plugin which points to a fedora 27 instance in openstack. Once this job
runs, the fedora-27 instance gets provisioned which will act as a host
for disk image building.