### PR TITLE
Adding new quality engineer

### DIFF
--- a/ci/jjb/jobs/macros.yaml
+++ b/ci/jjb/jobs/macros.yaml
@@ -125,6 +125,7 @@
             co-owners:
                 - brocha
                 - ragbalak
+                - bherring
 
 # Discard old builds that are month old for the job
 - property:


### PR DESCRIPTION
Problem:
* Need to add new hire `bherring` to the Jenkins notifications in pulp-ci

DoD:
* Add user and next nightly should notify and send an eMail to bherring

Testing:
* Have verified jjb credents with @kersommoura 
* Will push and verify functionality with everyone is happy with the review