### PR TITLE
Adding logic for duplicate image names

### DIFF
--- a/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
@@ -66,10 +66,10 @@ recreate_input_output_image_dirs(){
 }
 
 get_image_id_from_name(){
-# Retrieve Image IDs of images in OpenStack
+# Retrieve image ID for a given image name from OpenStack.
+# Since many images can have the same name, We select the id from one of the images.
 # param $1: Image_name
-
-    _image_id_temp="$(openstack image show -c id -f value ${1} 2> /dev/null)"
+    _image_id_temp="$(openstack image list --name "${1}" -c ID -f value | tail -1)"
 }
 
 


### PR DESCRIPTION
The current base image retrieval logic depends on the fact that the
given base image name is a unique one. However this logic fails with
errors when there are multiple mapping of images for the given image
name. Example ``rhel-7.4-server-x86_64-updated`` image name is used by
two images, causing diskimage builder to fail in downloading this base
image. Thus changing the logic such that only one image among duplicates
is used.