### PR TITLE
Remove atomic repository from pulp-2 installation playbook

### DIFF
--- a/ci/ansible/roles/subscription-manager/tasks/main.yaml
+++ b/ci/ansible/roles/subscription-manager/tasks/main.yaml
@@ -55,10 +55,6 @@
   command: subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-extras-rpms
   when: ansible_distribution_major_version|int >= 7
 
-- name: Enable atomic host repository
-  command: subscription-manager repos --enable rhel-atomic-host-rpms
-  when: ansible_distribution_major_version|int >= 7
-
 - name: Enable EPEL repository
   package:
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm


### PR DESCRIPTION
rhel-atomic-host-rpms is missing also figured out that we are not using this repository.