### PR TITLE
Adding python wrapper for getting latest openstack image.

### DIFF
--- a/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
@@ -68,8 +68,9 @@ recreate_input_output_image_dirs(){
 get_image_id_from_name(){
 # Retrieve image ID for a given image name from OpenStack.
 # Since many images can have the same name, We select the id from one of the images.
+# We use the ``./py_get_image_id`` python executable for getting the image id.
 # param $1: Image_name
-    _image_id_temp="$(openstack image list --name "${1}" -c ID -f value | tail -1)"
+    _image_id_temp="$(${scripts_dir}/py_get_image_id ${1})"
 }
 
 

--- a/ci/open_stack_plugin/disk_image_builder/scripts/py_get_image_id
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/py_get_image_id
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""
+This is a python executable that is used from ``builder.sh``.
+This file when called with an openstack image id as parameter,
+will output the latest image id of the given image name.
+"""
+from __future__ import print_function
+import time
+import os
+import sys
+
+from glanceclient import Client
+from keystoneauth1 import loading, session
+
+if len(sys.argv) < 2:
+    raise Exception('Usage py_get_image_id <image_name>')
+
+# Configures the python script to use open stack configurations.
+LOADER = loading.get_plugin_loader('password')
+AUTH = LOADER.load_from_options(
+    auth_url=os.environ['OS_AUTH_URL'],
+    username=os.environ['OS_USERNAME'],
+    password=os.environ['OS_PASSWORD'],
+    project_id=os.environ['OS_TENANT_ID']
+)
+
+SESSION = session.Session(auth=AUTH)
+GLANCE = Client('2', session=SESSION)
+# Zip the image ids and the timestamp together.
+# The `image['id']` is corresponding to the
+# image name ``sys.argv[1]``.
+IMAGES = [
+    (
+        image['id'],
+        time.mktime(time.strptime(image['updated_at'], '%Y-%m-%dT%H:%M:%SZ'))
+    )
+    for image in GLANCE.images.list()
+    if image['name'] == sys.argv[1]
+]
+# Get the latest image
+sorted(IMAGES, key=lambda x: x[1])
+print(IMAGES[-1][0])


### PR DESCRIPTION
This commit adds a new python executable which will be called by the
``builder.sh`` file. The executable is responsible for getting an input
image name, finding all the images in openstack matching the name, and
getting the latest image in terms of ``updated_at``.
