### PR TITLE
Update lazy role to use package module

### DIFF
--- a/ci/ansible/roles/lazy/tasks/main.yml
+++ b/ci/ansible/roles/lazy/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
 - name: Install lazy packages
-  action: "{{ ansible_pkg_mgr }} name={{ item }} state=latest"
-  loop:
-    - squid
-    - httpd
-    - python-pulp-streamer
+  package:
+    name:
+      - squid
+      - httpd
+      - python-pulp-streamer
+    state: present
 
 - name: Install squid proxy configuration
   copy: src=squid.conf dest=/etc/squid/squid.conf


### PR DESCRIPTION
Update lazy role to use package module instead of `ansible_pkg_mgr`.

See: https://docs.ansible.com/ansible/2.5/modules/package_module.html