### PR TITLE
Update python version on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: false
 language: python
+python:
+- 3.6
 install:
-  - pip install ansible 'jenkins-job-builder==2.0.2'
+  - pip install --upgrade pip
+  - pip install ansible 'jenkins-job-builder==2.0.2' 'requests<=2.20.0'
 script:
   - ansible-playbook --syntax-check ci/ansible/*.yaml
   - cd ci/jjb && jenkins-jobs --conf jenkins_jobs.ini test -r -o "$(mktemp --directory)" jobs


### PR DESCRIPTION
Update python version to python3.6 on Travis-CI, besides that add an extra step
to update pip. Besides that pin the requests library to be compatible with the
idna library, and avoid errors.