### PR TITLE
Remove CDN repos from upgrade jobs

### DIFF
--- a/ci/jjb/jobs/pulp-upgrade.yaml
+++ b/ci/jjb/jobs/pulp-upgrade.yaml
@@ -16,10 +16,6 @@
             files:
                 - file-id: rhn_credentials
                   variable: RHN_CREDENTIALS
-        - credentials-binding:
-            - file:
-                credential-id: c7fb90a7-154c-45d6-b820-a742cf300615
-                variable: CDN_CERTIFICATES
         - inject:
             properties-content: |
                 OS={os}

--- a/ci/jjb/scripts/post-upgrade.sh
+++ b/ci/jjb/scripts/post-upgrade.sh
@@ -16,9 +16,4 @@ pulp-admin rpm repo list --repo-id rpm-signed
 pulp-admin rpm repo list --repo-id srpm
 pulp-admin rpm repo list --repo-id sync-schedule
 
-if [[ -f "${CDN_CERTIFICATES}" ]]; then
-    pulp-admin rpm repo list --repo-id rhel6
-    pulp-admin rpm repo list --repo-id rhel7-rhn-tools
-fi
-
 pulp-admin logout

--- a/ci/jjb/scripts/pre-upgrade.sh
+++ b/ci/jjb/scripts/pre-upgrade.sh
@@ -2,29 +2,6 @@
 
 pulp-admin login -u "${PULP_USER:-admin}" -p "${PULP_PASSWORD:-admin}"
 
-if [[ -f "${CDN_CERTIFICATES}" ]]; then
-    tar -zxvf "${CDN_CERTIFICATES}"
-
-    pulp-admin rpm repo create \
-        --feed https://cdn.redhat.com/content/dist/rhel/rhui/server/6/6.7/x86_64/kickstart/ \
-        --feed-ca-cert cdn/cdn.redhat.com-chain.crt \
-        --feed-cert cdn/914f702153514b06c1ef279db9dcadce.crt \
-        --feed-key cdn/914f702153514b06c1ef279db9dcadce.key \
-        --remove-missing true \
-        --repo-id rhel6 \
-        --serve-http true
-    pulp-admin rpm repo sync run --repo-id rhel6
-
-    pulp-admin rpm repo create \
-        --feed https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/x86_64/rhn-tools/os/ \
-        --feed-ca-cert cdn/cdn.redhat.com-chain.crt \
-        --feed-cert cdn/914f702153514b06c1ef279db9dcadce.crt \
-        --feed-key cdn/914f702153514b06c1ef279db9dcadce.key \
-        --repo-id rhel7-rhn-tools \
-        --skip erratum
-    pulp-admin rpm repo sync run --repo-id rhel7-rhn-tools
-fi
-
 pulp-admin rpm repo create \
     --feed https://repos.fedorapeople.org/pulp/pulp/fixtures/drpm-unsigned/ \
     --relative-url drpm \


### PR DESCRIPTION
Remove CDN repos fro upgrade jobs. Until CDN access is sorted out.