### PR TITLE
Update pulp-fixtures trigger to build on Saturday only

### DIFF
--- a/ci/jjb/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jjb/jobs/pulp-fixtures-publisher.yaml
@@ -13,7 +13,7 @@
                 - '*/master'
             skip-tag: true
     triggers:
-        - timed: '@midnight'
+        - timed: 'H H * * 6'
     wrappers:
         - jenkins-ssh-credentials
     builders:


### PR DESCRIPTION
Part of the simplification of ci jobs.

The group decided the job only needs to be ran weekly. Matching
the usage pattern to be similar to disk-image-builder. Jenkins will
load balance the job start time on Saturday with the `H H'.

There is no ticket associated with this change other than a group discussion.