### PR TITLE
Update pulp version for backup and restore jobs

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -40,10 +40,10 @@
     os:
         - 'rhel7'
     pulp_version:
-        - '2.17'
+        - '2.18'
     pulp_build:
         - 'stable'
-    backup_version: '2.16'
+    backup_version: '2.17'
     backup_build: 'stable'
     backup_os: 'rhel7'
     jobs:
@@ -56,7 +56,7 @@
     pulp_build:
         - 'stable'
     pulp_version:
-        - '2.15'
+        - '2.18'
     jobs:
         - pulp-{pulp_version}-{pulp_build}-backup-{os}
 


### PR DESCRIPTION
Update pulp version used for backup and restores jobs. Current pulp
stable version is 2.18. Adjust accordingly.