### PR TITLE
Remove pulp 2.17 from pulp dev job

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -12,10 +12,8 @@
 
 # Jobs using pulp-dev.yaml for Pulp 2.17+.
 - project:
-    name: pulp-dev-2-17
+    name: pulp-dev-2-17+
     build_version:
-    - 2.17:
-        pulp_version: '2.17'
     - 2.18:
         pulp_version: '2.18'
     - 2-master:


### PR DESCRIPTION
Remove pulp 2.17 from pulp dev job. Currently stable version is pulp
version 2.18.