### PR TITLE
Adding rhel-os and rhel-np images for upgrade and unittest jobs

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -112,7 +112,7 @@
             - 1.6-release
           unittest_platforms:
             - f27-os
-            - rhel7-os
+            - rhel7-np
           unittest_whitelist:
             - mibanescu
           unittest_adminlist:
@@ -125,7 +125,7 @@
             - 3.1-release
           unittest_platforms:
             - f27-os
-            - rhel7-os
+            - rhel7-np
           unittest_whitelist: ""
           unittest_adminlist:
             - pulpbot
@@ -136,7 +136,7 @@
             - 1.3-release
           unittest_platforms:
             - f27-os
-            - rhel7-os
+            - rhel7-np
           unittest_whitelist: ""
           unittest_adminlist:
             - pulpbot
@@ -147,7 +147,7 @@
             - 2-master
           unittest_platforms:
             - f27-os
-            - rhel7-os
+            - rhel7-np
           unittest_whitelist: ""
           unittest_adminlist:
             - pulpbot
@@ -158,7 +158,7 @@
             - 2-master
           unittest_platforms:
             - f27-os
-            - rhel7-os
+            - rhel7-np
           unittest_whitelist: ""
           unittest_adminlist:
             - pulpbot
@@ -169,7 +169,7 @@
             - 2-master
           unittest_platforms:
             - f27-os
-            - rhel7-os
+            - rhel7-np
           unittest_whitelist: ""
           unittest_adminlist:
             - pulpbot

--- a/ci/jjb/jobs/unittests.yaml
+++ b/ci/jjb/jobs/unittests.yaml
@@ -9,7 +9,7 @@
           name: node-type
           values:
             - f27-os
-            - rhel7-os
+            - rhel7-np
     parameters:
         - string:
             name: sha1


### PR DESCRIPTION
The current rhel-os label was pointing to a nodepool node. This was
done since the rhel-os configured with Disk-Image-Builder is
incompatible with the `unit-test` jobs that requires older builds of
certain packages. However the nodepool nodes were making the upgrade job
to fail due to java installation. Thus this commit takes care of the
following

* Adding a new label rhel7-np for the Unit-Test jobs that runs on the
old nodepool built rhel7
* Configuring all the other jobs to run on the rhel7 build by
Disk-Image-Builder

Once this PR is merged, Will configure 
* rhel7-os
* rhel7-np

nodes inside jenkins to point to the appropriate machines.