### PR TITLE
Remove workaround python-django issue untill fixed

### DIFF
--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -127,14 +127,6 @@
     state: started
     enabled: true
 
-- name: Explicitly install python-django (https://bugzilla.redhat.com/show_bug.cgi?id=1524560)
-  package:
-    name: python-django
-    state: present
-  when:
-    - ansible_distribution == "RedHat"
-    - ansible_distribution_major_version|int == 7
-
 - name: Setup Pulp nightly repository
   template:
     src: yum_repo.j2


### PR DESCRIPTION
This workaround was introduced due to an error to install
`python-django16-1.6.11.6-7.el7`. This package is now in a newer
version. Remove this workaround.

Current python-django version available using epel: 1.11.13-4.el7o

See: https://pulp.plan.io/issues/4281