### PR TITLE
Adding Safe delete logic to disk image builder

### DIFF
--- a/ci/open_stack_plugin/disk_image_builder/scripts/py_get_image_id
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/py_get_image_id
@@ -38,5 +38,5 @@ IMAGES = [
     if image['name'] == sys.argv[1]
 ]
 # Get the latest image
-sorted(IMAGES, key=lambda x: x[1])
+IMAGES = sorted(IMAGES, key=lambda x: x[1])
 print(IMAGES[-1][0])


### PR DESCRIPTION
The current implementation of Disk Image Builder deletes an image in the
upstream without considering the status of the newly created image. Thus
even before the new image created is uploaded, the old image is deleted
. This was done to remove any name conflicts, however this creates a
threat of removing a working image in the case of failure. This commit
takes care of preserving the old image when the latest build fails.