### PR TITLE
Handling empty images in `py_get_image_id`

### DIFF
--- a/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/builder.sh
@@ -118,9 +118,12 @@ upload_image(){
     new_image="${_image_id_temp}"
 
     # If a newer image is present and it differs from the older image
+    # If there is a proper older image
     # We delete the older image
     if [ "${prev_image}" != "${new_image}" ]; then
-        remove_existing_image "${prev_image}"
+        if [ "${prev_image}" != "0" ]; then
+            remove_existing_image "${prev_image}"
+        fi
     fi
 
     recreate_input_output_image_dirs

--- a/ci/open_stack_plugin/disk_image_builder/scripts/py_get_image_id
+++ b/ci/open_stack_plugin/disk_image_builder/scripts/py_get_image_id
@@ -3,6 +3,8 @@
 This is a python executable that is used from ``builder.sh``.
 This file when called with an openstack image id as parameter,
 will output the latest image id of the given image name.
+
+If Image name doesn't exist it outputs '0' as the ID.
 """
 from __future__ import print_function
 import time
@@ -37,6 +39,10 @@ IMAGES = [
     for image in GLANCE.images.list()
     if image['name'] == sys.argv[1]
 ]
-# Get the latest image
-IMAGES = sorted(IMAGES, key=lambda x: x[1])
-print(IMAGES[-1][0])
+
+if len(IMAGES) == 0:
+    print('0')
+else:
+    # Get the latest image
+    IMAGES = sorted(IMAGES, key=lambda x: x[1])
+    print(IMAGES[-1][0])


### PR DESCRIPTION
The py_get_image_id script is used for getting image ids of the latest
images matching the input names. If no image is present, then the script
throws exceptions. To handle this, this commit will output id as 0 when
no image exists. The builder script will also delete previous images
only when previous images has a valid id.