### PR TITLE
Add pulp3 ci

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -27,7 +27,22 @@
     jobs:
     - pulp-{build_version}-dev-{os}
 
-# Job to install and test pulp 3
+# Jobs using pulp3-dev.yaml for Pulp 3+.
+- project:
+    name: pulp3-dev
+    build_version:
+    - master:
+        pulp_version: '3.0'
+        reverse_trigger: '3-master'
+    os:
+    - f28
+    - f29
+    reverse_trigger: '{build_version}-dev'
+    script-var: ''
+    jobs:
+    - pulp3-{build_version}-dev-{os}
+
+# Job to install and test pulp 3 in a single node
 - project:
     name: pulp-3-devel
     jobs:

--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -27,6 +27,11 @@
     jobs:
     - pulp-{build_version}-dev-{os}
 
+# Job to install and test pulp 3
+- project:
+    name: pulp-3-devel
+    jobs:
+      - pulp-3-devel
 
 - project:
     name: disk-image-builder-base

--- a/ci/jjb/jobs/pulp-3-devel.yaml
+++ b/ci/jjb/jobs/pulp-3-devel.yaml
@@ -1,18 +1,42 @@
 # Job that install Pulp 3 on any machine, and run functional tests.
 - job:
-    name: 'pulp-3-devel'
-    node: 'f28-os'
+    name: pulp-3-devel
+    node: f28-os
+    description: |
+      <p>Install a Pulp 3 development environment on a host, and smash it.</p>
+      <p>
+        The installation procedure assumes that Pulp and Pulp Smash should be
+        installed on localhost. As a result, actions like SSH configuration are
+        skipped.
+      </p>
+    properties:
+        - qe-ownership
+        - discard-old-builds
+    scm:
+        - pulp-ci-github
     wrappers:
+        - ansicolor
+        - timestamps
         - jenkins-ssh-credentials
+        - timeout:
+            # pulp-smash usually takes about an hour or two, so time it out
+            # after 7:40 hours. This gives room to some tasks time out.
+            timeout: 460
+            abort: true
     triggers:
       - timed: "H 2 * * *"
     builders:
         - fix-hostname
         - shell:
-            !include-raw-escape:
+            !include-raw:
                 - pulp3-install.sh
         - shell:
-            !include-raw-escape:
+            !include-raw:
               - pulp-3-devel-smasher.sh
     publishers:
+        - junit:
+            results: 'junit-report.xml'
+        - archive:
+            artifacts: '*.tar.gz'
+            allow-empty: true
         - delete-slave-node

--- a/ci/jjb/jobs/pulp-3-devel.yaml
+++ b/ci/jjb/jobs/pulp-3-devel.yaml
@@ -1,0 +1,18 @@
+# Job that install Pulp 3 on any machine, and run functional tests.
+- job:
+    name: 'pulp-3-devel'
+    node: 'f28-os'
+    wrappers:
+        - jenkins-ssh-credentials
+    triggers:
+      - timed: "H 2 * * *"
+    builders:
+        - fix-hostname
+        - shell:
+            !include-raw-escape:
+                - pulp3-install.sh
+        - shell:
+            !include-raw-escape:
+              - pulp-3-devel-smasher.sh
+    publishers:
+        - delete-slave-node

--- a/ci/jjb/jobs/pulp-3-devel.yaml
+++ b/ci/jjb/jobs/pulp-3-devel.yaml
@@ -1,7 +1,7 @@
 # Job that install Pulp 3 on any machine, and run functional tests.
 - job:
     name: pulp-3-devel
-    node: f28-os
+    node: f29-os
     description: |
       <p>Install a Pulp 3 development environment on a host, and smash it.</p>
       <p>
@@ -23,6 +23,10 @@
             # after 7:40 hours. This gives room to some tasks time out.
             timeout: 460
             abort: true
+        - config-file-provider:
+            files:
+                - file-id: rhn_credentials
+                  variable: RHN_CREDENTIALS
     triggers:
       - timed: "H 2 * * *"
     builders:
@@ -33,10 +37,11 @@
         - shell:
             !include-raw:
               - pulp-3-devel-smasher.sh
+        - capture-logs
     publishers:
         - junit:
             results: 'junit-report.xml'
         - archive:
-            artifacts: '*.tar.gz'
+            artifacts: '*.tar.gz,junit-report.xml,report.html'
             allow-empty: true
         - delete-slave-node

--- a/ci/jjb/jobs/pulp3-dev.yaml
+++ b/ci/jjb/jobs/pulp3-dev.yaml
@@ -1,0 +1,70 @@
+- job-template:
+    name: 'pulp3-{build_version}-dev-{os}'
+    node: '{os}-os'
+    properties:
+        - qe-ownership
+        - discard-old-builds
+    scm:
+        - pulp-ci-github
+    wrappers:
+        - config-file-provider:
+            files:
+                - file-id: rhn_credentials
+                  variable: RHN_CREDENTIALS
+        - inject:
+            properties-content: |
+                OS={os}
+                PULP_BUILD=nightly
+                PULP_VERSION={pulp_version}
+    triggers:
+      - timed: "H 2 * * *"
+    builders:
+        - fix-hostname
+        - shell:
+            !include-raw-escape:
+                - 'ssh-setup.sh'
+        - shell:
+            !include-raw:
+                - 'pulp3-install{script-var}.sh'
+        - shell:
+            !include-raw-escape:
+                - 'pulp3-smash-parameters.sh'
+        - inject:
+            properties-file: parameters.txt
+        - trigger-builds:
+            - project:
+                - pulp3-smash-runner
+              block: true
+              predefined-parameters: |
+                  PULP_SMASH_SYSTEM_HOSTNAME=$PULP_SMASH_SYSTEM_HOSTNAME
+              block-thresholds:
+                  build-step-failure-threshold: never
+                  unstable-threshold: never
+                  failure-threshold: never
+              parameter-factories:
+                  - factory: binaryfile
+                    parameter-name: PRIVATE_KEY
+                    file-pattern: pulp_server_key
+                    no-files-found-action: FAIL
+        - copyartifact:
+            project: pulp3-smash-runner
+            which-build: specific-build
+            build-number: ${{TRIGGERED_BUILD_NUMBER_PULP3_SMASH_RUNNER}}
+            flatten: true
+        - capture-logs
+    publishers:
+        - postbuildscript:
+            script-only-if-succeeded: False
+            script-only-if-failed: False
+            builders:
+              - shell: |
+                  if [[ "${{OS}}" =~ "rhel" ]]; then
+                      sudo subscription-manager unregister
+                  fi
+        - junit:
+            results: junit-report.xml
+        - archive:
+            artifacts: "*.tar.gz,report.html"
+            allow-empty: true
+        - email-notify-owners
+        - delete-slave-node

--- a/ci/jjb/jobs/pulp3-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp3-smash-runner.yaml
@@ -1,0 +1,114 @@
+- job:
+    name: pulp3-smash-runner
+    concurrent: true
+    properties:
+        - copyartifact:
+            projects: pulp3-*-dev-*
+    node: f29-os
+    parameters:
+        - string:
+            name: PULP_SMASH_SYSTEM_HOSTNAME
+    properties:
+        - qe-ownership
+        - discard-old-builds
+    scm:
+        - pulp-ci-github
+    wrappers:
+        - ansicolor
+        - timeout:
+            # pulp-smash usually takes about an hour or two, so time it out
+            # after 7:40 hours. This gives room to some tasks time out.
+            timeout: 460
+            abort: true
+        - timestamps
+    builders:
+        - fix-hostname
+        - shell: |
+            # Useful for debugging
+            getent passwd "$(id -u)"
+
+            # Setup ssh config and private key
+            mkdir ~/.ssh/controlmasters
+            cat > ~/.ssh/config <<EOF
+            Host ${PULP_SMASH_SYSTEM_HOSTNAME}
+                User jenkins
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
+                IdentityFile ${PWD}/PRIVATE_KEY
+                ControlMaster auto
+                ControlPersist 5m
+                ControlPath ~/.ssh/controlmasters/%C
+            EOF
+            chmod 600 PRIVATE_KEY ~/.ssh/config
+
+            echo "Is pulp working?"
+            curl -u admin:admin ${PULP_SMASH_SYSTEM_HOSTNAME}:80/pulp/api/v3/status/ | python3 -m json.tool
+
+            echo "Make the venv"
+            mkdir -p ~/.virtualenvs/
+            python3 -m venv ~/.virtualenvs/pulp-smash/
+            source ~/.virtualenvs/pulp-smash/bin/activate
+
+            echo "Install Pulp Smash"
+            pip install --upgrade pip
+            pip install git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
+            pip install pytest
+            pip install pytest-sugar
+            pip install pytest-html
+
+            echo "Configure smash"
+            mkdir -p ~/.config/pulp_smash
+            cat >~/.config/pulp_smash/settings.json <<EOF
+            {
+            "hosts": [
+                {
+                "hostname": "${PULP_SMASH_SYSTEM_HOSTNAME}",
+                "roles": {
+                    "api": {
+                    "port": 80,
+                    "scheme": "http",
+                    "service": "nginx",
+                    "verify": false
+                    },
+                    "pulp resource manager": {},
+                    "pulp workers": {},
+                    "redis": {},
+                    "shell": {
+                    "transport": "local"
+                    }
+                }
+                }
+            ],
+            "pulp": {
+                "auth": [
+                "admin",
+                "admin"
+                ],
+                "selinux enabled": false,
+                "version": "3.0"
+            }
+            }
+            EOF
+            pulp-smash settings path
+            pulp-smash settings show
+            pulp-smash settings validate
+
+            echo "Clone the repos"
+            git clone https://github.com/pulp/pulp --branch master
+            git clone https://github.com/pulp/pulp_file --branch master
+            git clone https://github.com/pulp/pulp_rpm.git --branch master
+            git clone https://github.com/pulp/pulp_docker.git --branch master
+
+            echo "Run pytest"
+            set +e
+            py.test -v --color=yes --html=report.html --self-contained-html --junit-xml=junit-report.xml pulp/pulpcore/tests/functional pulp_file/pulp_file/tests/functional pulp_rpm/pulp_rpm/tests/functional pulp_docker/pulp_docker/tests/functional
+            set -e
+
+            # check the report file exists
+            test -f junit-report.xml
+        - capture-logs
+    publishers:
+        - archive:
+            artifacts: '*.tar.gz,junit-report.xml,report.html'
+        - email-notify-owners
+        - delete-slave-node

--- a/ci/jjb/scripts/pulp-3-devel-smasher.sh
+++ b/ci/jjb/scripts/pulp-3-devel-smasher.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+# This script is used only by pulp-3-devel single node
+# for the pulp3-*-dev-* jobs see script in pulp3-smash-runner.yaml 
+
 echo "Is pulp working?"
 curl -u admin:admin "$(hostname --long)":80/pulp/api/v3/status/ | python3 -m json.tool
 
 mkdir -p ~/.virtualenvs/
 python3 -m venv ~/.virtualenvs/pulp-smash/
-bin_dir="$(realpath --canonicalize-existing ~/.virtualenvs/pulp-smash/bin/)"
 source ~/.virtualenvs/pulp-smash/bin/activate
 pip install --upgrade pip
 pip install git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
@@ -47,8 +49,9 @@ pulp-smash settings validate
 
 pip install pytest
 pip install pytest-sugar
-# clone all repos to run tests
+pip install pytest-html
 
+# clone all repos to run tests
 # pulp core
 git clone https://github.com/pulp/pulp --branch master
 # pulp file
@@ -60,7 +63,7 @@ git clone https://github.com/pulp/pulp_docker.git --branch master
 
 # Run pytest
 set +e
-py.test -v --color=yes --junit-xml=junit-report.xml pulp/pulpcore/tests/functional pulp_file/pulp_file/tests/functional pulp_rpm/pulp_rpm/tests/functional pulp_docker/pulp_docker/tests/functional
+py.test -v --color=yes --html=report.html --self-contained-html --junit-xml=junit-report.xml pulp/pulpcore/tests/functional pulp_file/pulp_file/tests/functional pulp_rpm/pulp_rpm/tests/functional pulp_docker/pulp_docker/tests/functional
 set -e
 
 # check the report file exists

--- a/ci/jjb/scripts/pulp-3-devel-smasher.sh
+++ b/ci/jjb/scripts/pulp-3-devel-smasher.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
+echo "Is pulp working?"
+curl -u admin:admin "$(hostname --long)":80/pulp/api/v3/status/ | python3 -m json.tool
 
 mkdir -p ~/.virtualenvs/
 python3 -m venv ~/.virtualenvs/pulp-smash/
@@ -45,8 +48,7 @@ pulp-smash settings validate
 pip install pytest
 pip install pytest-sugar
 # clone all repos to run tests
-mkdir -p ~/p3-tests/
-cd ~/p3-tests/ || exit
+
 # pulp core
 git clone https://github.com/pulp/pulp --branch master
 # pulp file
@@ -55,5 +57,11 @@ git clone https://github.com/pulp/pulp_file --branch master
 git clone https://github.com/pulp/pulp_rpm.git --branch master
 # pulp docker
 git clone https://github.com/pulp/pulp_docker.git --branch master
-py.test -v --color=yes --junit-xml=junit-report.xml --pyargs pulp/pulpcore/tests/functional pulp_file/pulp_file/tests/functional pulp_rpm/pulp_rpm/tests/functionalI pulp_docker/pulp_docker/tests/functional
+
+# Run pytest
+set +e
+py.test -v --color=yes --junit-xml=junit-report.xml pulp/pulpcore/tests/functional pulp_file/pulp_file/tests/functional pulp_rpm/pulp_rpm/tests/functional pulp_docker/pulp_docker/tests/functional
+set -e
+
+# check the report file exists
 test -f junit-report.xml

--- a/ci/jjb/scripts/pulp-3-devel-smasher.sh
+++ b/ci/jjb/scripts/pulp-3-devel-smasher.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+mkdir -p ~/.virtualenvs/
+python3 -m venv ~/.virtualenvs/pulp-smash/
+bin_dir="$(realpath --canonicalize-existing ~/.virtualenvs/pulp-smash/bin/)"
+source ~/.virtualenvs/pulp-smash/bin/activate
+pip install --upgrade pip
+pip install git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
+mkdir -p ~/.config/pulp_smash
+cat >~/.config/pulp_smash/settings.json <<EOF
+{
+  "hosts": [
+    {
+      "hostname": "$(hostname --long)",
+      "roles": {
+        "api": {
+          "port": 80,
+          "scheme": "http",
+          "service": "nginx",
+          "verify": false
+        },
+        "pulp resource manager": {},
+        "pulp workers": {},
+        "redis": {},
+        "shell": {
+          "transport": "local"
+        }
+      }
+    }
+  ],
+  "pulp": {
+    "auth": [
+      "admin",
+      "admin"
+    ],
+    "selinux enabled": false,
+    "version": "3.0"
+  }
+}
+EOF
+pulp-smash settings path
+pulp-smash settings show
+pulp-smash settings validate
+
+pip install pytest
+pip install pytest-sugar
+# clone all repos to run tests
+mkdir -p ~/p3-tests/
+cd ~/p3-tests/ || exit
+# pulp core
+git clone https://github.com/pulp/pulp --branch master
+# pulp file
+git clone https://github.com/pulp/pulp_file --branch master
+# pulp rpm
+git clone https://github.com/pulp/pulp_rpm.git --branch master
+# pulp docker
+git clone https://github.com/pulp/pulp_docker.git --branch master
+py.test -v --color=yes --junit-xml=junit-report.xml --pyargs pulp/pulpcore/tests/functional pulp_file/pulp_file/tests/functional pulp_rpm/pulp_rpm/tests/functionalI pulp_docker/pulp_docker/tests/functional
+test -f junit-report.xml

--- a/ci/jjb/scripts/pulp3-install.sh
+++ b/ci/jjb/scripts/pulp3-install.sh
@@ -1,18 +1,16 @@
-#!/usr/bin/env bash
+#!/bin/bash
 sudo dnf -y update
 sudo dnf -y install ansible git sed
 
 # make a temp dir to clone all the things
 tempdir="$(mktemp --directory)"
-pushd "${tempdir}"
+pushd "$tempdir"
 
 git clone https://github.com/pulp/ansible-pulp3.git
 
 # get the playbook locally
 curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/ansible.cfg > ansible.cfg
 curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/source-install-plugins.yml > install.yml
-
-sed -i -e "s/- name: Install pulpcore package from source/- name: Upgrade pip\n      pip:\n        name: pip\n        state: latest\n        virtualenv_command: '{{ pulp_python_interpreter }} -m venv'\n        virtualenv: '{{pulp_install_dir}}'\n\n    - name: Install pulpcore package from source/g" ./ansible-pulp3/roles/pulp3/tasks/install.yml
 
 echo "Installing roles."
 export ANSIBLE_ROLES_PATH="./ansible-pulp3/roles/"
@@ -22,7 +20,7 @@ echo "Available roles."
 ansible-galaxy list
 
 echo "Create hosts file."
-echo $HOSTNAME > hosts
+echo "$HOSTNAME" > hosts
 
 echo "Starting Pulp 3 Installation."
 ansible-playbook --connection local -i hosts -u root install.yml -v -e pulp_pip_editable=no

--- a/ci/jjb/scripts/pulp3-install.sh
+++ b/ci/jjb/scripts/pulp3-install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+sudo dnf -y update
+sudo dnf -y install ansible git sed
+
+# make a temp dir to clone all the things
+tempdir="$(mktemp --directory)"
+pushd "${tempdir}"
+
+git clone https://github.com/pulp/ansible-pulp3.git
+
+# get the playbook locally
+curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/ansible.cfg > ansible.cfg
+curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/source-install-plugins.yml > install.yml
+
+sed -i -e "s/- name: Install pulpcore package from source/- name: Upgrade pip\n      pip:\n        name: pip\n        state: latest\n        virtualenv_command: '{{ pulp_python_interpreter }} -m venv'\n        virtualenv: '{{pulp_install_dir}}'\n\n    - name: Install pulpcore package from source/g" ./ansible-pulp3/roles/pulp3/tasks/install.yml
+
+echo "Installing roles."
+export ANSIBLE_ROLES_PATH="./ansible-pulp3/roles/"
+ansible-galaxy install -r ./ansible-pulp3/requirements.yml
+
+echo "Available roles."
+ansible-galaxy list
+
+echo "Create hosts file."
+echo $HOSTNAME > hosts
+
+echo "Starting Pulp 3 Installation."
+ansible-playbook --connection local -i hosts -u root install.yml -v -e pulp_pip_editable=no

--- a/ci/jjb/scripts/pulp3-install.sh
+++ b/ci/jjb/scripts/pulp3-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo dnf -y update
-sudo dnf -y install ansible git sed
+sudo dnf -y install ansible git
 
 # make a temp dir to clone all the things
 tempdir="$(mktemp --directory)"
@@ -20,7 +20,8 @@ echo "Available roles."
 ansible-galaxy list
 
 echo "Create hosts file."
-echo "$HOSTNAME" > hosts
+echo 'localhost' > hosts
+source "${RHN_CREDENTIALS}"
 
 echo "Starting Pulp 3 Installation."
-ansible-playbook --connection local -i hosts -u root install.yml -v -e pulp_pip_editable=no
+ansible-playbook --connection local -i hosts -u root install.yml -v -e pulp_pip_editable=no -e pulp_content_host="$(hostname --long):8080"

--- a/ci/jjb/scripts/pulp3-smash-parameters.sh
+++ b/ci/jjb/scripts/pulp3-smash-parameters.sh
@@ -1,0 +1,1 @@
+echo "PULP_SMASH_SYSTEM_HOSTNAME=$(hostname --long)" > parameters.txt


### PR DESCRIPTION
Pulp 3 - Master added to jenkins CI

New jobs:
- pulp3-master-dev-f28
- pulp3-master-dev-f29
- pulp3-smash-runner

*NOTE:* The single node pulp-3-devel job left here because it can be useful as an example in the future.