### PR TITLE
Pin pytest version for Pulp 2 tests

### DIFF
--- a/ci/ansible/roles/pulp-2-tests/tasks/main.yml
+++ b/ci/ansible/roles/pulp-2-tests/tasks/main.yml
@@ -82,7 +82,7 @@
 - name: Install pytest
   pip:
     virtualenv: '{{ ansible_user_dir }}/.virtualenvs/pulp-2-tests'
-    name: pytest
+    name: pytest==4.1.0
     state: present
 
 - name: Create a Pulp Smash configuration directory


### PR DESCRIPTION
Latest version of pytest `4.2.0` in somehow changed the order of
tests running - mainly related to inheritance. Tests inherinted from the
``BaseAPICrudTestCase`` are running the  ``BaseAPICrudTestCase`` as a
test itself. This behaviour is not observed in older versions of pytest.

Pin pytest version until this behaviour is figured out.

See: https://github.com/pytest-dev/pytest/releases