### PR TITLE
Fix the shell transport settings for Pulp3-smash-runner job

### DIFF
--- a/ci/jjb/jobs/pulp3-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp3-smash-runner.yaml
@@ -73,9 +73,7 @@
                     "pulp resource manager": {},
                     "pulp workers": {},
                     "redis": {},
-                    "shell": {
-                    "transport": "local"
-                    }
+                    "shell": {}
                 }
                 }
             ],


### PR DESCRIPTION
According to the docs:

```
When set to “local,” Pulp Smash will locally execute commands for that host with Python’s built-in subprocess module
hen set to “ssh,” Pulp Smash will execute commands over SSH.
When omitted, Pulp Smash will guess how to execute commands by comparing the host’s declared hostname against the current host’s hostname. If the two hostnames are identical, Pulp Smash will behave as if “transport” is set to “local.” Otherwise, Pulp Smash will behave as if “transport” is set to “ssh.”
```

https://pulp-smash.readthedocs.io/en/latest/configuration.html#configuration-file-syntax