### PR TITLE
Firewall should be disable after pulp3 installation

### DIFF
--- a/ci/jjb/scripts/pulp3-install.sh
+++ b/ci/jjb/scripts/pulp3-install.sh
@@ -23,9 +23,9 @@ echo "Create hosts file."
 echo 'localhost' > hosts
 source "${RHN_CREDENTIALS}"
 
+echo "Starting Pulp 3 Installation."
+ansible-playbook --connection local -i hosts -u root install.yml -v -e pulp_pip_editable=no -e pulp_content_host="$(hostname --long):8080"
+
 echo "Disabling Firewall service to enable access to custom content ports"
 sudo systemctl disable firewalld
 sudo systemctl stop firewalld
-
-echo "Starting Pulp 3 Installation."
-ansible-playbook --connection local -i hosts -u root install.yml -v -e pulp_pip_editable=no -e pulp_content_host="$(hostname --long):8080"


### PR DESCRIPTION
Ansible installer re-enables the firewall, so in order to use the content_host the order of the command to disable it should be changed.