### PR TITLE
Modify priority for pulp repos

### DIFF
--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -4,6 +4,7 @@
   roles:
     - role: subscription-manager
       when: ansible_distribution == 'RedHat'
+    - role: pulp-priority
     - role: pulp-fips
       when:
         - enable_fips is defined

--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -164,16 +164,6 @@
       priority: 50
   when: pulp_build == "beta" or pulp_build == "stable"
 
-- name: Check fips state
-  shell: cat /proc/sys/crypto/fips_enabled
-  register: fips_state
-
-- name: Install yum-plugin-priorities
-  package:
-    name: yum-plugin-priorities
-    state: present
-  when: fips_state.stdout == '1'
-
 - name: Install Pulp Server
   package:
     name: '@pulp-server-qpid'


### PR DESCRIPTION
This is a work around to avoid packages provided by package team to
be overwritten by newer versions provided by epel.

See: https://pulp.plan.io/issues/4387