### PR TITLE
Changing pulp-packaging to run on rhel7-np

### DIFF
--- a/ci/jjb/jobs/pulp-packaging.yaml
+++ b/ci/jjb/jobs/pulp-packaging.yaml
@@ -5,7 +5,7 @@
 - job-template:
     name: 'pulp-packaging-{release_config}'
     defaults: ci-workflow-runtest
-    node: 'rhel7-os'
+    node: 'rhel7-np'
     properties:
         - build-ownership
     scm:


### PR DESCRIPTION
The current pulp-packaging job runs on rhel7-os instance which causes it
to fail due to package dependencies. This issue is rectified my making
it to run on rhel7-np instance(Which is an old Rhel 7.5 nodepool
instance). This commit modifies the pulp-packaging
job to run on rhel7-np . This is a temporary fix and will be moved to
rhel7-os once the issue with rhel7-os is fixed.