### PR TITLE
Changing Ansible Installer priorities with current 2.18.1 definition

### DIFF
--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -1,10 +1,16 @@
 ---
 
 - hosts: all
+  pre_tasks:
+    - name: Check fips state
+      shell: cat /proc/sys/crypto/fips_enabled
+      register: fips_state
+  vars:
+    repo_priority: "{{ '50' if fips_state.stdout == '1'  else '99' }}"
+
   roles:
     - role: subscription-manager
       when: ansible_distribution == 'RedHat'
-    - role: pulp-priority
     - role: pulp-fips
       when:
         - enable_fips is defined

--- a/ci/ansible/roles/pulp-priority/tasks/main.yml
+++ b/ci/ansible/roles/pulp-priority/tasks/main.yml
@@ -1,5 +1,0 @@
----
-- name: Install yum-plugin-priorities
-  package:
-    name: yum-plugin-priorities
-    state: present

--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -137,7 +137,7 @@
       name: Pulp Project repository
       baseurl: "https://repos.fedorapeople.org/pulp/pulp/testing/automation/{{ pulp_version }}/stage/{% if ansible_distribution == 'Fedora' %}fedora-{% endif %}$releasever/$basearch/"
       gpgcheck: 0
-      priority: 50
+      priority: "{{ repo_priority }}"
   when: pulp_build == "nightly"
 
 - name: Setup Pulp nightly koji repository
@@ -149,7 +149,7 @@
       name: Pulp Project repository
       baseurl: "http://koji.katello.org/releases/yum/pulp-nightly/pulp/{% if ansible_distribution == 'Fedora' %}fedora-{% endif %}$releasever/$basearch/"
       gpgcheck: 0
-      priority: 50
+      priority: "{{ repo_priority }}"
   when: pulp_build == "nightly_koji"
 
 - name: Setup Pulp beta or stable repository
@@ -161,8 +161,14 @@
       name: Pulp Project repository
       baseurl: "https://repos.fedorapeople.org/pulp/pulp/{{ pulp_build }}/{{ pulp_version }}/{% if ansible_distribution == 'Fedora' %}fedora-{% endif %}$releasever/$basearch/"
       gpgcheck: 0
-      priority: 50
+      priority: "{{ repo_priority }}"
   when: pulp_build == "beta" or pulp_build == "stable"
+
+- name: Install yum-plugin-priorities
+  package:
+    name: yum-plugin-priorities
+    state: present
+  when: fips_state.stdout == '1'
 
 - name: Install Pulp Server
   package:


### PR DESCRIPTION
To solve an EPEL versioning problem with the python-celery stack, the final solution during build has changed the EPOCH on NEVRA for those RPMs to 10:

The resulting logic needed to be updated to:
* use priority on FIPS with EPEL
* do not use priority on non-FIPS with EPEL

The end state of each of those upgrade permutations leave the box in the same RPM state without the end-user to have to play with yum or repository priorities.

Removing the pulp-priority role as it is now deprecated with these changes.

The included, tested changes are the output of the solution for CI.

refs #4387