### PR TITLE
Updating Jenkins Pulp Upgrade Permutations after 2.18.1 GA

### DIFF
--- a/ci/jjb/README.md
+++ b/ci/jjb/README.md
@@ -180,7 +180,7 @@ template defines some required and minimal set of options:
 - All jobs should have a owner.
 - All owners should receive an email if his/her jobs fail or are not built.
 - Before finishing the job, the node should be marked offline in order to avoid
-  issues with Jenkins reusing a node that is about to be deleted by Nodepool.
+  issues with Jenkins reusing a node.
 
 To start a new job from the template `cp` it into an YAML file:
 

--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -95,8 +95,10 @@
         - rhel7-fips
     pulp_version:
         - 2.17-stable
+        - 2.18-stable
     upgrade_pulp_version:
         - 2.18-stable
+        - 2.19-stable
     jobs:
         - 'pulp-upgrade-{pulp_version}-{upgrade_pulp_version}-{os}'
 


### PR DESCRIPTION
Following the GA of 2.18.1, adding the 2.18 upgrade to 2.19.

For the current time, 2.17 is not being removed.

Updated the `README` to remove a specific phrase about Node Pool.

refs #4359