### PR TITLE
Update pulp role to define defaults for repo_priority and evaluate run-time

### DIFF
--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -1,13 +1,6 @@
 ---
 
 - hosts: all
-  pre_tasks:
-    - name: Check fips state
-      shell: cat /proc/sys/crypto/fips_enabled
-      register: fips_state
-  vars:
-    repo_priority: "{{ '50' if fips_state.stdout == '1'  else '99' }}"
-
   roles:
     - role: subscription-manager
       when: ansible_distribution == 'RedHat'

--- a/ci/ansible/roles/pulp/defaults/main.yaml
+++ b/ci/ansible/roles/pulp/defaults/main.yaml
@@ -5,3 +5,7 @@ pulp_version: 2.17
 
 # Pulp build to install, the choices are: beta, nightly and stable
 pulp_build: nightly
+
+# Default highest repo priority. 
+default_priority: 99
+fips_priority: 55

--- a/ci/ansible/roles/pulp/tasks/main.yaml
+++ b/ci/ansible/roles/pulp/tasks/main.yaml
@@ -1,4 +1,13 @@
 ---
+# Must check fips state here as pulp-fips could have
+- name: Check fips state
+  shell: cat /proc/sys/crypto/fips_enabled
+  register: fips_state
+
+- name: Set the repo_priority based on fips_state 
+  set_fact:
+    repo_priority: "{{  fips_priority if fips_state.stdout == '1'  else default_priority }}"
+
 # Pulp 2 requires Python 2.
 - name: Install Python 2 (Fedora)
   package:


### PR DESCRIPTION
Update pulp role to define defaults for repo_priorty and evaluate run-time

As an addendum to PR #644 , the repo_priorty variable in the pulp role must be defined within the scope of the role (not the pulp_server playbook) as other playbooks use that role (broke pulp_backup playbook). 

Making changes to:
- Declare a default of '99' in the pulp/defaults, which is the same as no priority
- Evaluate the proper priority within the role/pulp role for the pulp.repos
- Remove the pre_task declaration from the pulp_server playbook

Retested on fips (99, no plugin) and non-fips (50, plugin) with the pulp_server playbook as well as other playbooks dependent on the pulp role.

refs #4359