### PR TITLE
Update pulp 3 smash runner to use pulpcore

### DIFF
--- a/ci/jjb/jobs/pulp3-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp3-smash-runner.yaml
@@ -92,14 +92,14 @@
             pulp-smash settings validate
 
             echo "Clone the repos"
-            git clone https://github.com/pulp/pulp --branch master
+            git clone https://github.com/pulp/pulpcore --branch master
             git clone https://github.com/pulp/pulp_file --branch master
             git clone https://github.com/pulp/pulp_rpm.git --branch master
             git clone https://github.com/pulp/pulp_docker.git --branch master
 
             echo "Run pytest"
             set +e
-            py.test -v --color=yes --html=report.html --self-contained-html --junit-xml=junit-report.xml pulp/pulpcore/tests/functional pulp_file/pulp_file/tests/functional pulp_rpm/pulp_rpm/tests/functional pulp_docker/pulp_docker/tests/functional
+            py.test -v --color=yes --html=report.html --self-contained-html --junit-xml=junit-report.xml pulpcore/pulpcore/tests/functional pulp_file/pulp_file/tests/functional pulp_rpm/pulp_rpm/tests/functional pulp_docker/pulp_docker/tests/functional
             set -e
 
             # check the report file exists


### PR DESCRIPTION
Update pulp 3 smash runner to use pulpcore. Since pulp files were moved
to pulpcore repository.