### PR TITLE
Removing cronjob trigger on disk-image-builder

### DIFF
--- a/ci/jjb/jobs/disk-image-builder.yaml
+++ b/ci/jjb/jobs/disk-image-builder.yaml
@@ -5,8 +5,6 @@
         - qe-ownership
     scm:
         - pulp-ci-github
-    triggers:
-        - timed: 'H H * * 6'
     wrappers:
         - config-file-provider:
             files:


### PR DESCRIPTION
## Problem

The `disk-image-builder` is still running on a cron through Jenkins with (purposefully) no configured OS template to run. The job will hang indefinitely.

## Solution 

Removing the weekly cron to now only run on-demand.
