### PR TITLE
Change Pulp 3 Default Ports

### DIFF
--- a/ci/docs-builder.py
+++ b/ci/docs-builder.py
@@ -141,7 +141,7 @@ def main():
 
     # Get the latest api.yaml file to build the rest api docs
     if is_pulp3:
-        with urllib.request.urlopen("http://localhost:8000/pulp/api/v3/docs/api.yaml") as response, \
+        with urllib.request.urlopen("http://localhost:24817/pulp/api/v3/docs/api.yaml") as response, \
                 open(os.path.join(docs_directory, "api.yaml"), 'wb') as api_file:
             data = response.read()
             api_file.write(data)

--- a/ci/docs/testrubyserver.rb
+++ b/ci/docs/testrubyserver.rb
@@ -3,7 +3,7 @@ require 'webrick'
 include WEBrick
 
 config = {}
-config.update(:Port => 8080)
+config.update(:Port => 24816)
 config.update(:BindAddress => ARGV[0])
 config.update(:DocumentRoot => ARGV[1])
 server = HTTPServer.new(config)

--- a/ci/jjb/jobs/pulp3-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp3-smash-runner.yaml
@@ -71,7 +71,7 @@
                     "verify": false
                     },
                     "content": {
-                    "port": 8080,
+                    "port": 24816,
                     "scheme": "http",
                     "service": "pulp_content_app",
                     "verify": false
@@ -111,7 +111,7 @@
             registries = ["docker.io", "registry.fedoraproject.org", "quay.io", "registry.access.redhat.com", "registry.centos.org"]
 
             [registries.insecure]
-            registries = ["${PULP_SMASH_SYSTEM_HOSTNAME}:8080"]
+            registries = ["${PULP_SMASH_SYSTEM_HOSTNAME}:24816"]
 
             [registries.block]
             registries = []

--- a/ci/jjb/scripts/openstack-provision-machine.sh
+++ b/ci/jjb/scripts/openstack-provision-machine.sh
@@ -26,7 +26,7 @@ fi
 
 if ! openstack security group rule list "${KEY_NAME}" | grep -q "0.0.0.0/0"; then
     openstack security group rule create --protocol icmp "${KEY_NAME}"
-    for tcp_port in 22 80 443 5000 5646 5647 5671 8000 8140 8443 9090; do
+    for tcp_port in 22 80 443 5000 5646 5647 5671 24817 8140 8443 9090; do
         openstack security group rule create --protocol tcp --dst-port "${tcp_port}" "${KEY_NAME}"
     done
     for udp_port in 53 69; do

--- a/ci/jjb/scripts/pulp3-install.sh
+++ b/ci/jjb/scripts/pulp3-install.sh
@@ -24,7 +24,7 @@ echo 'localhost' > hosts
 source "${RHN_CREDENTIALS}"
 
 echo "Starting Pulp 3 Installation."
-ansible-playbook --connection local -i hosts -u root install.yml -v -e pulp_pip_editable=no -e pulp_content_host="$(hostname --long):8080"
+ansible-playbook --connection local -i hosts -u root install.yml -v -e pulp_pip_editable=no -e pulp_content_host="$(hostname --long):24816"
 
 echo "Disabling Firewall service to enable access to custom content ports"
 sudo systemctl disable firewalld


### PR DESCRIPTION
https://pulp.plan.io/issues/4556

Content: 8080 -> 24816
API: 8000 -> 24817

[noissue]
Required PR: https://github.com/pulp/pulpcore/pull/75

@rochacbruno Offered to make this update, but I figured I would try anyway. I am a bit surprised; it looks like this repo sometimes was using port 80 for the API, as seen in ci/jjb/jobs/pulp3-smash-runner.yaml