### PR TITLE
Adding rhel7 to Pulp-3-Master matrix, removing f28

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -35,8 +35,8 @@
         pulp_version: '3.0'
         reverse_trigger: '3-master'
     os:
-    - f28
     - f29
+    - rhel7
     reverse_trigger: '{build_version}-dev'
     script-var: ''
     jobs:


### PR DESCRIPTION
Part 1:

- Adding `rhel7` to `os` list.

Expected:

- We expect it to fail, lets see exactly how and lets have a job to debug.

Part 2: (coming next)

- This failure will push us to work on it.