### PR TITLE
Remove fips role call from pulp_server

### DIFF
--- a/ci/ansible/pulp_server.yaml
+++ b/ci/ansible/pulp_server.yaml
@@ -4,10 +4,6 @@
   roles:
     - role: subscription-manager
       when: ansible_distribution == 'RedHat'
-    - role: pulp-fips
-      when:
-        - enable_fips is defined
-        - enable_fips
     - role: pulp
     - role: lazy
       when: pulp_version is version('2.8', '>=')


### PR DESCRIPTION
FIPS role is not being used on `pulp_server.yaml`. In general images are
already FIPS enabled when calling this playbook.