### PR TITLE
Removing RHEL7 OS from JJB for Pulp3

### DIFF
--- a/ci/jjb/jobs/projects.yaml
+++ b/ci/jjb/jobs/projects.yaml
@@ -36,7 +36,6 @@
         reverse_trigger: '3-master'
     os:
     - f29
-    - rhel7
     reverse_trigger: '{build_version}-dev'
     script-var: ''
     jobs:


### PR DESCRIPTION
Removing the JJB support for RHEL7.

Additions of Pulp3 to RHEL8 will be completed in SATQE-3338.