### PR TITLE
Remove junit from nightly upgrade to avoid test harness failures with java

### DIFF
--- a/ci/jjb/jobs/pulp-upgrade.yaml
+++ b/ci/jjb/jobs/pulp-upgrade.yaml
@@ -92,7 +92,5 @@
       - archive:
           artifacts: "*.tar.gz"
           allow-empty: true
-      - junit:
-          results: junit-report.xml
       - email-notify-owners
       - delete-slave-node


### PR DESCRIPTION
## Problem
Nightly upgrade is failing with java dependencies causing junit
to return "false" test failures. 

## Failure Output

```
ERROR: Step ‘Publish JUnit test result report’ aborted due to exception: 
java.io.FileNotFoundException: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.191.b12-1.el7_6.x86_64/jre/lib/resources.jar
```

## Solution
Remove the junit check, for now.

## Follow-up
Additional ticket of SATQE-3254 and -3118 will investigate the java dependency
error and look to remove junit with additional testing and investigation.