### PR TITLE
Problem: f27 no longer supported

### DIFF
--- a/ci/jjb/jobs/unittests.yaml
+++ b/ci/jjb/jobs/unittests.yaml
@@ -8,7 +8,6 @@
           type: label-expression
           name: node-type
           values:
-            - f27-os
             - rhel7-np
     parameters:
         - string:


### PR DESCRIPTION
Solution: remove f27 from unittest matrix

[noissue]