### PR TITLE
Update node to run tests for Pulp 2

### DIFF
--- a/ci/jjb/jobs/pulp-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp-smash-runner.yaml
@@ -4,7 +4,7 @@
     properties:
         - copyartifact:
             projects: pulp-*-dev-*
-    node: f28-os
+    node: f29-os
     parameters:
         - string:
             name: PULP_SMASH_SYSTEM_HOSTNAME


### PR DESCRIPTION
Update node to run tests for Pulp 2 from F28 to F29.