### PR TITLE
Update pulp-fixtures-publisher to use f30-os and include docker

### DIFF
--- a/ci/jjb/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jjb/jobs/pulp-fixtures-publisher.yaml
@@ -3,7 +3,7 @@
 
 - job-template:
     name: 'pulp-fixtures-publisher'
-    node: 'docker-os'
+    node: 'f30-os'
     properties:
         - qe-ownership
     scm:
@@ -21,6 +21,7 @@
         - shell: |
             sudo dnf -y install \
               createrepo \
+              docker \
               fedpkg \
               gpg \
               jq \
@@ -31,9 +32,10 @@
               python3-jinja2-cli \
               rpm-build \
               rpm-sign
+            sudo systemctl start docker
             sudo gpasswd --add "$(whoami)" mock
             newgrp -
-            make fixtures base_url=https://repos.fedorapeople.org/pulp/pulp/
+            sudo make fixtures base_url=https://repos.fedorapeople.org/pulp/pulp/
             rsync -arvze "ssh -o StrictHostKeyChecking=no" --delete \
                 fixtures/* \
                 pulpadmin@repos.fedorapeople.org:/srv/repos/pulp/pulp/fixtures


### PR DESCRIPTION
# Problem

Need to update the base image that is being used by pulp-fixtures to `f30-os`.

# Solution 

* Need to include docker as part of the install of packages since that is unique to the fixtures project for this image.
* Update the base image to `f30-os`
* The `f30-os` image was already created by hand and uploaded to Openstack

# Testing
* https://pulp-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/pulp-fixtures-publisher/1047

# References
See: https://projects.engineering.redhat.com/browse/SATQE-3467