### PR TITLE
Adding rsync to the fixtures publisher for f30

### DIFF
--- a/ci/jjb/jobs/pulp-fixtures-publisher.yaml
+++ b/ci/jjb/jobs/pulp-fixtures-publisher.yaml
@@ -31,7 +31,8 @@
               puppet \
               python3-jinja2-cli \
               rpm-build \
-              rpm-sign
+              rpm-sign \
+              rsync
             sudo systemctl start docker
             sudo gpasswd --add "$(whoami)" mock
             newgrp -


### PR DESCRIPTION
## Problem

With the change to F30 as the base ISO, rsync now needs to be added
to the install list.

This was missed on the previous update.

## Solution

Corrected, added, and tested in re-build 1051 on the job.