### PR TITLE
Increase pulp2 versioning informaton for audit

### DIFF
--- a/ci/jjb/jobs/pulp-dev.yaml
+++ b/ci/jjb/jobs/pulp-dev.yaml
@@ -32,6 +32,7 @@
             !include-raw-escape:
                 - 'pulp-coverage-setup.sh'
                 - 'pulp-smash-parameters.sh'
+                - 'pulp-version-information.sh'
         - inject:
             properties-file: parameters.txt
         - trigger-builds:

--- a/ci/jjb/scripts/pulp-version-information.sh
+++ b/ci/jjb/scripts/pulp-version-information.sh
@@ -1,0 +1,6 @@
+# Verbose version of the install
+pulp-admin login -u "${PULP_USER:-admin}" -p "${PULP_PASSWORD:-admin}"
+pulp-admin status
+
+# All pulp RPMs installed for audit against fedora people
+rpm -qa | grep -i pulp | sort


### PR DESCRIPTION
## Problem

During any test run, there may be a question about the content of the install of an install.

## Solution

Adding the full information for ``pulp-admin status`` and all pulp installed RPMs to compare against repos.fedorapeople.org. 

This should allow an auditor to use the result to compare instead of having to spawn a new machine to then compare the running version. That may not be possible at times as the testing repos are not under QE control.

## Test Runs

* [Run 1](https://pulp-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Pulp%202%20-%20Master/job/pulp-2-master-dev-rhel7/468/console)
* [Run 2](https://pulp-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Pulp%202%20-%20Master/job/pulp-2-master-dev-rhel7-fips/357/console)

Example output of the runs conducted on Jenkins Jobs would look like the following running after the  ``pulp_coverage`` role

### pulp status

```
...
[0m[92mSuccessfully logged in. Session certificate will expire at Jun  5 15:46:14 2019
GMT.[0m

+ pulp-admin status
[0m+----------------------------------------------------------------------+
                          Status of the server
+----------------------------------------------------------------------+

Api Version:           2
Database Connection:   
  Connected: True
Known Workers:         
  _id:            reserved_resource_worker-0@host-10-0-149-170.openstacklocal
  _ns:            workers
  Last Heartbeat: 2019-05-29T15:46:12Z
  _id:            scheduler@host-10-0-149-170.openstacklocal
  _ns:            workers
  Last Heartbeat: 2019-05-29T15:46:13Z
  _id:            resource_manager@host-10-0-149-170.openstacklocal
  _ns:            workers
  Last Heartbeat: 2019-05-29T15:46:15Z
Messaging Connection:  
  Connected: True
Versions:              
  Platform Version: 2.20a1
```
### rpm -qa | sort

```
+ sort
+ rpm -qa
+ grep -i pulp
pulp-admin-client-2.20.0-0.1.alpha.201905291507gitfb8a31f.el7.noarch
pulp-deb-admin-extensions-1.10.0-0.1.alpha.201905291515gitefbfa1f.el7.noarch
pulp-deb-plugins-1.10.0-0.1.alpha.201905291515gitefbfa1f.el7.noarch
pulp-docker-admin-extensions-3.4.0-0.1.alpha.201905291443git69bf508.el7.noarch
pulp-docker-plugins-3.4.0-0.1.alpha.201905291443git69bf508.el7.noarch
pulp-ostree-admin-extensions-1.4.0-0.1.alpha.201905291447gitcc1c559.el7.noarch
pulp-ostree-plugins-1.4.0-0.1.alpha.201905291447gitcc1c559.el7.noarch
pulp-puppet-admin-extensions-2.20.0-0.1.alpha.201905291449gitacf3d7b.el7.noarch
pulp-puppet-plugins-2.20.0-0.1.alpha.201905291449gitacf3d7b.el7.noarch
pulp-puppet-tools-2.20.0-0.1.alpha.201905291449gitacf3d7b.el7.noarch
...
```