### PR TITLE
Add vault job for pulp2

### DIFF
--- a/ci/ansible/roles/pulp-2-tests/defaults/main.yml
+++ b/ci/ansible/roles/pulp-2-tests/defaults/main.yml
@@ -15,3 +15,10 @@ pulp_smash_api_verify: "false"
 
 # AMQP broker service either qpidd or rabbitmq
 pulp_smash_amqp_broker_service: "qpidd"
+
+
+# Repository to fetch pulp-smash
+pulp_smash_repo: git+https://github.com/PulpQE/pulp-smash.git@master#egg=pulp-smash
+
+# Repository to fetch the tests
+pulp_2_tests_repo: git+https://github.com/PulpQE/pulp-2-tests.git@master#egg=pulp-2-tests

--- a/ci/ansible/roles/pulp-2-tests/tasks/main.yml
+++ b/ci/ansible/roles/pulp-2-tests/tasks/main.yml
@@ -70,13 +70,13 @@
 - name: Install Pulp Smash
   pip:
     virtualenv: '{{ ansible_user_dir }}/.virtualenvs/pulp-2-tests'
-    name: git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
+    name: '{{ pulp_smash_repo }}'
     state: present
 
 - name: Install Pulp 2 Tests
   pip:
     virtualenv: '{{ ansible_user_dir }}/.virtualenvs/pulp-2-tests'
-    name: git+https://github.com/PulpQE/pulp-2-tests.git#egg=pulp-2-tests
+    name: '{{ pulp_2_tests_repo }}'
     state: present
 
 - name: Install pytest

--- a/ci/ansible/roles/subscription-manager/tasks/main.yaml
+++ b/ci/ansible/roles/subscription-manager/tasks/main.yaml
@@ -44,6 +44,7 @@
 
 - name: Subscription Manager disable all repositories
   command: subscription-manager repos --disable *
+  when: keep_existing_repositories is undefined
 
 - name: Enable main repository
   command: subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-rpms

--- a/ci/jjb/jobs/pulp-vault.yaml
+++ b/ci/jjb/jobs/pulp-vault.yaml
@@ -1,0 +1,247 @@
+# Job that help installing Pulp on any machine. This is useful for setting up
+# machines for running Pulp Smash.
+- job:
+    name: 'pulp2-vault'
+    concurrent: true
+    node: 'f29-os'
+    description: |
+        <p>
+          This job will:
+            - Provision an OpenStack instance using image provided in UPSHIFTIMAGE.
+            - Install PULP_VERSION on the running instance.
+            - Install and configure PULP_SMASH using SMASH_REPO.
+            - Clone test cases using TEST_REPO.
+            - If UPGRADE_OS
+                - Run sanity tests defined in PRE_PYTEST_ARGS.
+                - Upgrade O.S using OS_LATEST_REPO.
+            - Run final test suite using POST_PYTEST_ARGS.
+            - Store results.
+        </p>
+
+    parameters:
+        - string:
+            name: UPSHIFTIMAGE
+            default: rhel-7.6-server-x86_64-released
+            description: The name of the image available on Openstack, pulp will be installed on that instance and after sanity check upgrade will be performed.
+        - bool:
+            name: UPGRADE_OS
+            default: true
+            description: Mark if you want to have O.S upgrades, uncheck if you only want to run tests on the O.S without upgrading.
+        - bool:
+            name: DELETE_INSTANCE
+            default: false
+            description: Mark if you want to have the instance deleted after success.
+        - string:
+            name: OS_LATEST_REPO
+            default: http://download.devel.redhat.com/composes/nightly/latest-RHEL-7.7/compose/Server/x86_64/os/
+            description: Repository to use when upgrading the O.S before running the test suite.
+        - string:
+            name: OS_LATEST_REPO_OPTIONAL
+            default: http://download.devel.redhat.com/composes/nightly/latest-RHEL-7.7/compose/Server-optional/x86_64/os/
+            description: Optional Repository to use when upgrading the O.S before running the test suite.
+        - string:
+           name: UPSHIFTINSTANCEPREFIX
+           default: vault
+           description: instance will be named <prefix>-uuid
+        - string:
+           name: UPSHIFTUSER
+           default: psi-pulp-jenkins
+           description: User used to login to Openstack, the UPSHIFTPASSWORD will be read from jenkins credentials.
+        - string:
+           name: UPSHIFTPROJECTID
+           default: 144f871271034aa9960c449982fa36f7
+           description: Can be found on OPenstack user interface.
+        - string:
+           name: UPSHIFTPROJECTNAME
+           default: pulp-jenkins
+           description: Can be found on OPenstack user interface.
+        - string:
+           name: UPSHIFTAUTHURL
+           default: https://rhos-d.infra.prod.upshift.rdu2.redhat.com:13000/v3
+           description: Can be found on OPenstack user interface.
+
+        - string:
+            name: PULP_VERSION
+            default: '2.19'
+            description: Version to install before the update. set it to the version before the latest use only X.Y (no Z)
+        - string:
+            name: PRE_PYTEST_ARGS
+            default: -v --color=yes --pyargs pulp_2_tests.tests.platform.api_v2.test_login
+            description: Pytest sanity check (quick test) to run before upgrading the O.S.
+        - string:
+            name: POST_PYTEST_ARGS
+            default: -v --color=yes --junit-xml=junit-report.xml --pyargs pulp_2_tests.tests
+            description: Pytest command to run after the upgrade of O.S.
+
+
+        - string:
+            name: SMASH_REPO
+            default: git+https://github.com/PulpQE/pulp-smash.git@master#egg=pulp-smash
+        - string:
+            name: TEST_REPO
+            default: git+https://github.com/PulpQE/pulp-2-tests.git@master#egg=pulp-2-tests
+
+
+        - string:
+            name: PULP_SMASH_PULP_VERSION
+            default: '2.19.1'
+            decription: The Pulp version Pulp Smash will consider when running tests after the upgrade. Specify the .Z stream if needed.
+        - string:
+            name: PULP_SMASH_PULP_USERNAME
+            default: admin
+        - string:
+            name: PULP_SMASH_PULP_PASSWORD
+            default: admin
+        - choice:
+            name: PULP_SMASH_AMQP_BROKER_SERVICE
+            choices:
+                - qpidd
+                - rabbitmq
+        - choice:
+            name: PULP_SMASH_API_SCHEME
+            choices:
+                - https
+                - http
+        - bool:
+            name: PULP_SMASH_API_VERIFY
+            default: false
+    
+    properties:
+      - qe-ownership
+    scm:
+        # - pulp-ci-github
+        - git:
+            url: https://github.com/rochacbruno/pulp-ci.git
+            branches:
+                - '*/vaultjob'
+            skip-tag: true
+    wrappers:
+        - ansicolor
+        - timeout:
+            # pulp-smash usually takes about an hour or two, so time it out
+            # after 7:40 hours. This gives room to some tasks time out.
+            timeout: 460
+            abort: true
+        - timestamps
+        - config-file-provider:
+            files:
+                - file-id: rhn_credentials
+                  variable: RHN_CREDENTIALS
+        - jenkins-ssh-credentials
+        - credentials-binding:
+            - text:
+                credential-id: UPSHIFTPASSWORD
+                variable: UPSHIFTPASSWORD
+    builders:
+        - fix-hostname
+        - shell:
+            sudo dnf -y install nc
+        - shell:
+            !include-raw:
+              # Creates parameters.txt
+              - 'create_upshift_instance.sh'
+        - inject:
+            # injects PULP_HOSTNAME
+            properties-file: parameters.txt
+        - shell: |
+            # Useful for debugging
+            getent passwd "$(id -u)"
+
+            # Setup ssh config and private key
+            mkdir ~/.ssh/controlmasters
+            
+            cat > ~/.ssh/config <<EOF
+            Host ${PULP_HOSTNAME}
+                User cloud-user
+                StrictHostKeyChecking no
+                UserKnownHostsFile /dev/null
+                IdentityFile ~/.ssh/id_rsa
+                ControlMaster auto
+                ControlPersist 5m
+                ControlPath ~/.ssh/controlmasters/%C
+            EOF
+            
+            chmod 600 ~/.ssh/id_rsa ~/.ssh/config
+
+        - shell:
+            !include-raw:
+                - 'fix_remote_hostname.sh'
+
+        - shell: |
+            # Install Pulp System
+            sudo dnf -y install ansible
+            
+            export ANSIBLE_HOST_KEY_CHECKING=False
+            echo "${PULP_HOSTNAME} ansible_user=cloud-user" > hosts
+            source "${RHN_CREDENTIALS}"
+            export ANSIBLE_CONFIG="${PWD}/ci/ansible/ansible.cfg"
+            ansible-playbook -i hosts \
+                ci/ansible/pulp_server.yaml \
+                -e "pulp_build=stable" \
+                -e "pulp_version='${PULP_VERSION}'" \
+                -e "rhn_username=${RHN_USERNAME}" \
+                -e "rhn_password=${RHN_PASSWORD}" \
+                -e "rhn_pool=${RHN_POOL}" \
+                -e "keep_existing_repositories=true"
+
+            # Remote pre-requisites
+            ssh cloud-user@"${PULP_HOSTNAME}" << EOF
+               sudo yum -y install ansible attr git libselinux-python
+               sudo systemctl stop firewalld
+               sudo systemctl disable firewalld
+            EOF
+
+        - shell: |
+            # install and run smash tests
+            sudo dnf -y install attr git libselinux-python
+
+            ansible-playbook --connection local --inventory "localhost," ci/ansible/pulp_2_tests.yaml \
+                -e pulp_smash_system_hostname="${PULP_HOSTNAME}" \
+                -e pulp_smash_shell_transport="ssh" \
+                -e pulp_smash_amqp_broker_service="${PULP_SMASH_AMQP_BROKER_SERVICE}" \
+                -e pulp_smash_api_scheme="${PULP_SMASH_API_SCHEME}" \
+                -e pulp_smash_api_verify="${PULP_SMASH_API_VERIFY}" \
+                -e pulp_smash_pulp_username="${PULP_SMASH_PULP_USERNAME}" \
+                -e pulp_smash_pulp_password="${PULP_SMASH_PULP_PASSWORD}" \
+                -e pulp_smash_pulp_version="${PULP_SMASH_PULP_VERSION}" \
+                -e pulp_smash_repo="${SMASH_REPO}" \
+                -e pulp_2_tests_repo="${TEST_REPO}"
+            
+            source ~/.virtualenvs/pulp-2-tests/bin/activate
+            export PULP_SMASH_LOG_LEVEL=DEBUG
+            pulp-smash settings show
+
+            # Run Initial Sanity Check 
+            set +e
+            py.test ${PRE_PYTEST_ARGS}
+            set -e
+
+        - shell:
+            # To be used for the update of Pulp
+            # This script reads the OS_LATEST_REPO variable
+            # and is conditional to UPGRADE_OS bool.
+            !include-raw:
+                - 'upgrade_rhel_to_latest.sh'
+
+        - shell: | 
+            # Remote pre-requisites
+            ssh cloud-user@"${PULP_HOSTNAME}" << EOF
+               sudo systemctl stop firewalld
+               sudo systemctl disable firewalld
+            EOF
+            
+            # Re-run the tests after upgrade
+            source ~/.virtualenvs/pulp-2-tests/bin/activate
+            pulp-smash settings show
+            export PULP_SMASH_LOG_LEVEL=DEBUG
+            set +e
+            py.test ${POST_PYTEST_ARGS}
+            set -e
+        
+    publishers:
+        - archive:
+            artifacts: 'junit-report.xml'
+        - junit:
+            results: junit-report.xml
+        - email-notify-owners
+        - delete-slave-node

--- a/ci/jjb/scripts/create_upshift_instance.py
+++ b/ci/jjb/scripts/create_upshift_instance.py
@@ -1,0 +1,101 @@
+import os
+import openstack.cloud
+from uuid import uuid4
+openstack.enable_logging(debug=True)
+
+# connection
+
+# By reading the clouds.yaml file
+# conn = openstack.connect(cloud='openstack')
+
+# By passing parameters
+"""
+export UPSHIFTINSTANCEPREFIX=foobar
+export UPSHIFTUSER=my-username
+export UPSHIFTPROJECTID=4389570597635298632fhbg8435u85
+export UPSHIFTAUTHURL=https://xxx.xxx.xxxx.xxx.xxx.redhat.com:13000/v3
+export UPSHIFTIMAGE=rhel-7.7-server-x86_64-latest
+export UPSHIFTPASSWORD=sup3rs3c43t
+export UPSHIFTPROJECTNAME=my-project
+"""
+
+# Config variables
+AUTH_URL = os.environ.get('UPSHIFTAUTHURL')
+USERNAME = os.environ.get('UPSHIFTUSER')
+PASSWORD = os.environ.get('UPSHIFTPASSWORD')
+PROJECT_ID = os.environ.get(
+    'UPSHIFTPROJECTID',
+    '144f871271034aa9960c449982fa36f7'
+)
+PROJECT_NAME = os.environ.get(
+    'UPSHIFTPROJECTNAME',
+    'pulp-jenkins'
+)
+DOMAIN_NAME = os.environ.get("UPSHIFTDOMAINNAME", "redhat.com")
+INTERFACE = os.environ.get("UPSHIFTINTERFACE", "public")
+IDENTITY_API_VERSION = os.environ.get("UPSHIFTIDENTITYAPIVERSION", '3')
+IMAGE = os.environ.get(
+    'UPSHIFTIMAGE',
+    'rhel-7.6-server-x86_64-released '
+)
+FLAVOR = os.environ.get("UPSHIFTFLAVOR", "ci.m3.medium")
+NETWORK = os.environ.get("UPSHIFTNETWORK", "provider_net_shared_2")
+INSTANCE_PREFIX = os.environ.get('UPSHIFTINSTANCEPREFIX', 'default')
+KEYNAME = os.environ.get("UPSHIFTKEYNAME", "jenkins")
+
+# Connection
+conn = openstack.connection.Connection(
+    region_name='regionOne',
+    auth=dict(
+        auth_url=AUTH_URL,
+        username=USERNAME,
+        password=PASSWORD,
+        project_id=PROJECT_ID,
+        project_name=PROJECT_NAME,
+        user_domain_name=DOMAIN_NAME,
+    ),
+    interface=INTERFACE,
+    identity_api_version=IDENTITY_API_VERSION,
+)
+
+# entities
+image = conn.image.find_image(IMAGE)
+flavor = conn.get_flavor(FLAVOR)
+network = conn.network.find_network(NETWORK)
+
+# instance
+name = "{0}-{1}".format(INSTANCE_PREFIX, uuid4().hex)
+
+server = conn.create_server(
+    str(name),
+    image=image,
+    flavor=flavor,
+    network=network,
+    key_name=KEYNAME,
+    wait=True,
+    auto_ip=True,
+)
+# vm-10-0-79-72.hosted.upshift.rdu2.redhat.com.
+hostname = "vm-{0}.hosted.upshift.rdu2.redhat.com".format(
+    server.accessIPv4.replace('.', '-')
+)
+
+parameters = """
+PULP_HOSTNAME={hostname}
+UPSHIFTSERVERID={server_id}
+"""
+
+with open('parameters.txt', 'w') as param_file:
+    param_file.write(
+        parameters.format(
+            hostname=hostname,
+            server_id=server.id
+        )
+    )
+
+print("Instance ID:", server.id)
+print("IP:", server.accessIPv4)
+print("Hostname:", hostname)
+
+if os.environ.get('UPSHIFTDEBUG'):
+    import ipdb; ipdb.set_trace()

--- a/ci/jjb/scripts/create_upshift_instance.sh
+++ b/ci/jjb/scripts/create_upshift_instance.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+sudo pip install -U pip virtualenv
+virtualenv pulp-jenkins
+source pulp-jenkins/bin/activate
+pip install openstacksdk==0.31.1
+
+echo $PWD
+ls
+python ci/jjb/scripts/create_upshift_instance.py
+
+# wait for ssh connection
+sleep 60

--- a/ci/jjb/scripts/fix_remote_hostname.sh
+++ b/ci/jjb/scripts/fix_remote_hostname.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# wait for ssh connection
+for i in $(seq 1 20); do printf "%s." "$i";sleep 2; nc -vzw 2 "${PULP_HOSTNAME}" 22 && break; done
+echo "$PULP_HOSTNAME"
+# This information can aid in debugging failed jobs.
+ssh cloud-user@"${PULP_HOSTNAME}" << 'EOF'
+hostname --all-fqdn
+hostname
+# Setting the hostname of the system to enable connectivity
+hostname="$(hostname --all-fqdn | grep upshift | head -n 1)"
+hostname="$(echo ${hostname})"
+if [ -n "${hostname:-}" ]; then
+    # Set hostname the systemd way if possible, else fall back to manual way.
+    if [ "$(which hostnamectl 2>/dev/null)" ]; then
+    sudo hostnamectl set-hostname "${hostname}"
+    else
+    sudo hostname "${hostname}"
+    sudo tee /etc/hostname <<< "${hostname}"
+    fi
+fi
+EOF

--- a/ci/jjb/scripts/reboot_upshift_instance.py
+++ b/ci/jjb/scripts/reboot_upshift_instance.py
@@ -1,0 +1,53 @@
+import os
+import openstack.cloud
+openstack.enable_logging(debug=True)
+
+# connection
+
+# By reading the clouds.yaml file
+# conn = openstack.connect(cloud='openstack')
+
+# By passing parameters
+"""
+export UPSHIFTINSTANCEPREFIX=foobar
+export UPSHIFTUSER=my-username
+export UPSHIFTPROJECTID=4389570597635298632fhbg8435u85
+export UPSHIFTAUTHURL=https://xxx.xxx.xxxx.xxx.xxx.redhat.com:13000/v3
+export UPSHIFTIMAGE=rhel-7.7-server-x86_64-latest
+export UPSHIFTPASSWORD=sup3rs3c43t
+export UPSHIFTPROJECTNAME=my-project
+"""
+# Config variables
+AUTH_URL = os.environ.get('UPSHIFTAUTHURL')
+USERNAME = os.environ.get('UPSHIFTUSER')
+PASSWORD = os.environ.get('UPSHIFTPASSWORD')
+PROJECT_ID = os.environ.get(
+    'UPSHIFTPROJECTID',
+    '144f871271034aa9960c449982fa36f7'
+)
+PROJECT_NAME = os.environ.get(
+    'UPSHIFTPROJECTNAME',
+    'pulp-jenkins'
+)
+DOMAIN_NAME = os.environ.get("UPSHIFTDOMAINNAME", "redhat.com")
+INTERFACE = os.environ.get("UPSHIFTINTERFACE", "public")
+IDENTITY_API_VERSION = os.environ.get("UPSHIFTIDENTITYAPIVERSION", '3')
+
+# Connection
+conn = openstack.connection.Connection(
+    region_name='regionOne',
+    auth=dict(
+        auth_url=AUTH_URL,
+        username=USERNAME,
+        password=PASSWORD,
+        project_id=PROJECT_ID,
+        project_name=PROJECT_NAME,
+        user_domain_name=DOMAIN_NAME,
+    ),
+    interface=INTERFACE,
+    identity_api_version=IDENTITY_API_VERSION,
+)
+
+server = conn.get_server(os.environ.get('UPSHIFTSERVERID'))
+conn.compute.reboot_server(server.id, "SOFT")
+conn.compute.wait_for_server(server)

--- a/ci/jjb/scripts/upgrade_rhel_to_latest.sh
+++ b/ci/jjb/scripts/upgrade_rhel_to_latest.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${UPGRADE_OS}" = "true" ]; then
+# start upgrade part
+
+ssh cloud-user@${PULP_HOSTNAME} << EOF
+sudo bash -c 'cat > /etc/yum.repos.d/rhellatest.repo' <<- HERE
+	[rhellatest]
+	name=rhellatest
+	baseurl="${OS_LATEST_REPO}"
+	enabled=1
+	gpgcheck=0
+	
+	[rhellatestoptional]
+	name=rhellatestoptional
+	baseurl="${OS_LATEST_REPO_OPTIONAL}"
+	enabled=1
+	gpgcheck=0
+	HERE
+EOF
+
+ssh cloud-user@${PULP_HOSTNAME} << EOF
+pulp-admin -v status
+echo "Pre upgrade version:"
+cat /etc/os-release
+sudo yum repolist
+sudo systemctl stop httpd pulp_workers pulp_resource_manager pulp_celerybeat pulp_streamer
+sudo yum update -y
+sudo yum upgrade -y
+sudo -u apache pulp-manage-db
+sudo systemctl start httpd pulp_workers pulp_resource_manager pulp_celerybeat pulp_streamer
+sleep 2
+pulp-admin -v status
+echo "Post upgrade version:"
+cat /etc/os-release
+EOF
+
+sudo pip install -U pip virtualenv
+virtualenv pulp-jenkins
+source pulp-jenkins/bin/activate
+pip install openstacksdk==0.31.1
+
+python ci/jjb/scripts/reboot_upshift_instance.py
+
+echo "$PULP_HOSTNAME"
+
+# wait for ssh connection
+sleep 60
+
+# end upgrade part
+fi


### PR DESCRIPTION
This job will:
 - Provision a new machine on OpenStack 
 - Install INITIAL_PULP_VERSION (usually one version before the latest). 
 - Install pulp-smash from SMASH_REPO.
- Clone pulp-2-testsfrom TEST_REPO.
- Run py.test sanity check using args provided in PRE_PYTEST_ARGS.
- If it passes then it will upgrade O.S using OS_LATEST_REPO.
- Reboot the instance
- Then it will run the tests again this time using POST_PYTEST_ARGS.