### PR TITLE
Updating DNS grep from openshift to upshift

### DIFF
--- a/ci/jjb/jobs/macros.yaml
+++ b/ci/jjb/jobs/macros.yaml
@@ -56,7 +56,7 @@
             hostname --all-fqdn
             hostname
             # Setting the hostname of the system to enable connectivity
-            hostname="$(hostname --all-fqdn | grep openstacklocal | head -n 1)"
+            hostname="$(hostname --all-fqdn | grep upshift | head -n 1)"
             hostname="$(echo ${hostname})"
             if [ -n "${hostname:-}" ]; then
               # Set hostname the systemd way if possible, else fall back to manual way.


### PR DESCRIPTION
## Problem

A recent change in DNS requires a change to the reverse lookup grep. Without this token update, the PULP_SMASH_HOSTNAME for Ansible will cause errors in CI.

A future change will need to be made to update the remainder of this problem as the CI networks are no longer providing dnssearch capability through the use of hostname --all-fqdn

## Solution

For now, just update the ``grep`` to upshift with the base network change.

A future solution will be implemented where the base OS will be updated to include ``bind-utils`` and a reverse lookup of the IP will be completed within the JJB and passed to the pulp-smash server


## Reference:
* https://projects.engineering.redhat.com/browse/SATQE-4683