### PR TITLE
Updates to add hostname to /etc/hosts since DNS is unreliable

### DIFF
--- a/ci/jjb/jobs/pulp-dev.yaml
+++ b/ci/jjb/jobs/pulp-dev.yaml
@@ -42,6 +42,7 @@
               predefined-parameters: |
                   PULP_SMASH_SYSTEM_HOSTNAME=$PULP_SMASH_SYSTEM_HOSTNAME
                   PULP_SMASH_PULP_VERSION=$PULP_SMASH_PULP_VERSION
+                  PULP_SMASH_SYSTEM_IP=$PULP_SMASH_SYSTEM_IP
               block-thresholds:
                   build-step-failure-threshold: never
                   unstable-threshold: never
@@ -72,15 +73,6 @@
                     -e pulp_coverage_report_xml=true
                 cp /tmp/report.xml coverage.xml
             fi
-        # TODO: Uncomment and update the configuration when sonar is ready to
-        # be used
-        # - conditional-step:
-        #     condition-kind: regex-match
-        #     regex: '2.8'
-        #     label: '${{ENV,var="PULP_VERSION"}}'
-        #     steps:
-        #         - sonar:
-        #             sonar-name: 'Sonar Test Server'
         - capture-logs
     publishers:
         - postbuildscript:

--- a/ci/jjb/jobs/pulp-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp-smash-runner.yaml
@@ -8,9 +8,13 @@
     parameters:
         - string:
             name: PULP_SMASH_SYSTEM_HOSTNAME
+            description: A defined name of the smash system to go into /etc/hosts
+        - string:
+            name: PULP_SMASH_SYSTEM_IP
+            description: A defined IPv4 of the smash system to go into /etc/hosts
         - string:
             name: PULP_SMASH_PULP_VERSION
-            decription: The Pulp version Pulp Smash will consider when running tests.
+            description: The Pulp version Pulp Smash will consider when running tests.
         - string:
             name: PULP_SMASH_PULP_USERNAME
             default: admin
@@ -91,6 +95,10 @@
             EOF
             fi
             chmod 600 PRIVATE_KEY ~/.ssh/config
+
+            # Add PULP_SMASH_SYSTEM_HOSTNAME to /etc/hosts
+            # This step replaces faulty DNS
+            sudo sed -i -e "\$a${PULP_SMASH_SYSTEM_IP} ${PULP_SMASH_SYSTEM_HOSTNAME}\\" /etc/hosts
 
             # Set up the CA certificate that signed Pulp's apache server.
             export PULP_CA_CERT_PATH="/etc/pki/ca-trust/source/anchors/pulp-cacert.pem"

--- a/ci/jjb/scripts/pulp-smash-parameters.sh
+++ b/ci/jjb/scripts/pulp-smash-parameters.sh
@@ -6,3 +6,6 @@ if [ "${PULP_VERSION}" != "$(cut -d. -f-2 <<< "${PULP_RPM_VERSION}")" ]; then
 fi
 echo "PULP_SMASH_PULP_VERSION=${PULP_RPM_VERSION}" >> parameters.txt
 cp /etc/pki/CA/cacert.pem cacert.pem
+
+# Adding hosts information to /etc/hosts
+echo "PULP_SMASH_SYSTEM_IP=$(hostname -I | awk '{print $1}')" >> parameters.txt


### PR DESCRIPTION
## Problem

PnT DNS for our CI network is not reliable or not returning the fully qualified hostname from DNS.

## Solution
Updating required jobs to pass the IP and HOSTNAME to pulp-smash and pulp-smash to expect those parameters to add to /etc/hosts.

If these parameters are NOT defined, a blank line is added to /etc/hosts.

If DNS IS working, the previous hostname definition should continue to work allowing for previously functioning behavior.

## WIP
Testing on the latest non-functioning DNS as the final test (IP)