### PR TITLE
Temporarily update the API service

### DIFF
--- a/ci/jjb/jobs/pulp3-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp3-smash-runner.yaml
@@ -67,7 +67,7 @@
                     "api": {
                     "port": 24817,
                     "scheme": "http",
-                    "service": "pulp-api.service",
+                    "service": "nginx",
                     "verify": false
                     },
                     "content": {


### PR DESCRIPTION
Pulp-Smash needs to be update to allow a api service other than nginx
and apache for pulp3.

See: https://pulp.plan.io/issues/4965