### PR TITLE
Add update before install pulp

### DIFF
--- a/ci/ansible/roles/subscription-manager/tasks/main.yaml
+++ b/ci/ansible/roles/subscription-manager/tasks/main.yaml
@@ -59,3 +59,9 @@
   package:
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
     state: present
+
+- name: Update all packages to latest
+  package:
+    name: "*"
+    state: latest
+  become: yes


### PR DESCRIPTION
Add update before install pulp to assure that system is up to date.