### PR TITLE
Fix ownership for Pulp 2 dev job

### DIFF
--- a/ci/jjb/jobs/macros.yaml
+++ b/ci/jjb/jobs/macros.yaml
@@ -101,6 +101,18 @@
                 - dalley
                 - ttereshc
 
+# Ownership for pulp 2 jobs
+- property:
+    name: pulp2-ownership
+    properties:
+        - ownership:
+            owner: dkliban
+            co-owners:
+                - bherring
+                - brocha
+                - ggainey
+                - koliveir
+
 # Ownership that indicates developers are the primary contact for the job
 - property:
     name: dev-ownership

--- a/ci/jjb/jobs/pulp-dev.yaml
+++ b/ci/jjb/jobs/pulp-dev.yaml
@@ -2,9 +2,8 @@
     name: 'pulp-{build_version}-dev-{os}'
     node: '{os}-os'
     properties:
-        - dev-ownership
+        - pulp2-ownership
         - discard-old-builds
-        - qe-ownership
     scm:
         - pulp-ci-github
     wrappers:


### PR DESCRIPTION
Fix ownership for Pulp 2 dev job. Creates `pulp2-ownership` property to
be shared among QE and DEV team.