### PR TITLE
Temporarily exclude java to be upgraded

### DIFF
--- a/ci/ansible/roles/subscription-manager/tasks/main.yaml
+++ b/ci/ansible/roles/subscription-manager/tasks/main.yaml
@@ -64,4 +64,5 @@
   package:
     name: "*"
     state: latest
+    exclude: java*
   become: yes


### PR DESCRIPTION
Exclude java to be upgrade to the latest stable version. Since it is
causing failures on CI. Temporarily solution already tested.