### PR TITLE
Fixing attrs to version 19.1.0 to avoid pytest 'convert' issues

### DIFF
--- a/ci/jjb/jobs/pulp-smash-runner.yaml
+++ b/ci/jjb/jobs/pulp-smash-runner.yaml
@@ -128,6 +128,8 @@
             fi
             source ~/.virtualenvs/pulp-2-tests/bin/activate
             set +e
+            ## SATQE-5885: Reverting to attrs==19.1.0 w/breaking 19.2.0 change
+            pip install attrs==19.1.0
             py.test -v --color=yes --junit-xml=junit-report.xml --pyargs pulp_2_tests.tests
             set -e
             test -f junit-report.xml


### PR DESCRIPTION
## Problem

With an update to attrs==19.2.0, a conflict was noted in pytest with an error
about "keyword arguement 'convert'.

## Short-term Solution
Reinstalling version 19.1.0 to avoid this problem in the short-term and allow
ci to start functioning again.

## Long-term Solution
A long-term solution relative to pytest==4.1.0 pinning needs to be resolved,
which is the crux of the issue.
