### PR TITLE
Unpin pytest version Pulp 2 tests

### DIFF
--- a/ci/ansible/roles/pulp-2-tests/tasks/main.yml
+++ b/ci/ansible/roles/pulp-2-tests/tasks/main.yml
@@ -82,7 +82,7 @@
 - name: Install pytest
   pip:
     virtualenv: '{{ ansible_user_dir }}/.virtualenvs/pulp-2-tests'
-    name: pytest==4.1.0
+    name: pytest>4.2.0
     state: present
 
 - name: Create a Pulp Smash configuration directory


### PR DESCRIPTION
Unpin pytest version Pulp 2 tests.

See: https://github.com/pytest-dev/pytest/releases
Also: https://github.com/pulp/pulp-ci/pull/638