### PR TITLE
Add geerlingguy.postgresql to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 ci/nodepool/scripts/id_rsa.pub
 ci/nodepool/scripts/rhel*-rcm-internal.repo
+ci/ansible/roles/geerlingguy.postgresql
 
 # Ignore PyCharm
 .idea/*


### PR DESCRIPTION
[noissue]

This role is checked out locally when using `vagrant up pulp2-nightly-pulp3-source-centos7` in pulplift.
I suggest adding it to the `.gitignore` file.