### PR TITLE
Adding more repos to PR processor

### DIFF
--- a/.github/pr_processor.py
+++ b/.github/pr_processor.py
@@ -7,7 +7,17 @@ from github.GithubException import UnknownObjectException
 from redminelib import Redmine
 
 ORG = "pulp"
-REPOS = ["pulpcore", "pulp_file", "pulp_rpm", "pulp_container"]
+REPOS = [
+    "pulpcore",
+    "pulp_file",
+    "pulp_rpm",
+    "pulp_container",
+    "pulp_ansible",
+    "pulp_deb",
+    "pulp-certguard",
+    "pulp_installer",
+    "pulp_rpm_prerequisites",
+]
 SINCE = datetime.utcnow() - timedelta(hours=1)
 KEYWORDS = ["fixes", "closes", "re", "ref"]
 PR_STATUS = 3  # POST
@@ -102,4 +112,4 @@ for repo in REPOS:
                 continue
 
             labels = pr.labels + [label]
-            grepo.get_issue(pr.number).edit(labels=[l.name for l in labels])
+            grepo.get_issue(pr.number).edit(labels=[lbl.name for lbl in labels])


### PR DESCRIPTION
- pulp_ansible
- pulp_deb
- pulp-certguard
- pulp_installer
- pulp_rpm_prerequisites

pulp_installer and pulp_rpm_prerequisites not adding cherrypick label