### PR TITLE
Start tagging the PR processor comment

### DIFF
--- a/.github/pr_processor.py
+++ b/.github/pr_processor.py
@@ -102,6 +102,7 @@ for repo in REPOS:
                     comment += f"Warning: Issue [#{r_issue.id}]({r_issue.url}) is not at NEW/ASSIGNED/POST.\n\n"
                     redmine.issue.update(issue_num, notes=f"PR: {pr.html_url}")
 
+        comment += "\n\n<!-- pr_proccessor -->"
         grepo.get_issue(pr.number).create_comment(comment)
 
         # ADD LABELS


### PR DESCRIPTION
This will be useful when the PR processor has to revisit PRs and find its comment. See https://pulp.plan.io/issues/6720 as an example.