### PR TITLE
Create badge status for staging docs publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository is the home of Pulp's CI files.
 ## Pulp Project CI Overview
 
 [![pulp-oci-images CI](https://github.com/pulp/pulp-oci-images/actions/workflows/pulp_images.yml/badge.svg)](https://github.com/pulp/pulp-oci-images/actions/workflows/pulp_images.yml)
+[![Docs Publication Nightly CI](https://github.com/pulp/pulpcore/actions/workflows/staging-docs.yml/badge.svg)](https://github.com/pulp/pulpcore/actions/workflows/staging-docs.yml)
 
 Plugin | Nightly | CI Update | CLI
 :---|---:|---:|---:


### PR DESCRIPTION
Because the nighly schedule was added [here](https://github.com/pulp/pulpcore/pull/5215).

[noissue]